### PR TITLE
Add a prettify type to make the presented MergeObjects type more read…

### DIFF
--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -494,10 +494,7 @@ describe('merge', () => {
       async ({ id }) => ({ resultB: id - 1 }),
     )
 
-    const c: DomainFunction<{ resultA: number } & { resultB: number }> = merge(
-      a,
-      b,
-    )
+    const c: DomainFunction<{ resultA: number; resultB: number }> = merge(a, b)
 
     assertEquals(await c({ id: 1 }), {
       success: true,
@@ -518,9 +515,11 @@ describe('merge', () => {
     const c = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => ({ resultC: Boolean(id) }),
     )
-    const d: DomainFunction<
-      { resultA: string } & { resultB: number } & { resultC: boolean }
-    > = merge(a, b, c)
+    const d: DomainFunction<{
+      resultA: string
+      resultB: number
+      resultC: boolean
+    }> = merge(a, b, c)
 
     const results = await d({ id: 1 })
     assertEquals(results, {
@@ -581,10 +580,7 @@ describe('merge', () => {
       async ({ id }) => ({ resultB: id }),
     )
 
-    const c: DomainFunction<{ resultA: string } & { resultB: string }> = merge(
-      a,
-      b,
-    )
+    const c: DomainFunction<{ resultA: string; resultB: string }> = merge(a, b)
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -632,6 +628,7 @@ describe('merge', () => {
       async ({ id }) => ({ resultB: id - 1 }),
     )
 
+    // @ts-expect-error the inferred type is huge bc it has all properties from the number primitive
     const c: DomainFunction<number & { resultB: number }> = merge(a, b)
 
     assertEquals(await c({ id: 1 }), {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,15 @@ type UnpackAll<List, output extends unknown[] = []> = List extends [
   ? UnpackAll<rest, [...output, first]>
   : output
 
-type MergeObjs<Objs extends unknown[], output = {}> = Objs extends [
-  infer first,
-  ...infer rest,
-]
-  ? MergeObjs<rest, output & first>
-  : output
+type MergeObjs<Objs extends unknown[], output = {}> = Prettify<
+  Objs extends [infer first, ...infer rest]
+    ? MergeObjs<rest, output & first>
+    : output
+>
+
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
 
 type TupleToUnion<T extends unknown[]> = T[number]
 


### PR DESCRIPTION
…able

I learned this trick few days ago in [this thread](https://twitter.com/GabrielVergnaud/status/1622899119856525313).

It will make the output type of a `merge` combination more readable:

## Before
![Screenshot 2023-02-20 at 14 21 34](https://user-images.githubusercontent.com/566971/220168922-2f277b4f-aca7-4ff6-bcbf-fa37a9115f61.png)

## After
![Screenshot 2023-02-20 at 14 22 07](https://user-images.githubusercontent.com/566971/220168931-5dcdfe79-9819-40d6-947f-842d4bb42524.png)

