### PR TITLE
Add a new `collect` combinator and warn about pitfalls with `merge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ It does this by enforcing the parameters' types at runtime (through [zod](https:
   - [Tracing](#tracing)
 - [Combining domain functions](#combining-domain-functions)
   - [all](#all)
-  - [first](#first)
+  - [namedAll](#namedall)
   - [merge](#merge)
+  - [first](#first)
   - [pipe](#pipe)
   - [sequence](#sequence)
   - [map](#map)
@@ -40,7 +41,6 @@ It does this by enforcing the parameters' types at runtime (through [zod](https:
   - [inputFromFormData](#inputfromformdata)
   - [inputFromUrl](#inputfromurl)
   - [inputFromSearch](#inputfromsearch)
-- [Need help?](#need-help)
 - [Resources](#resources)
 - [Acknowlegements](#acknowlegements)
 
@@ -389,6 +389,79 @@ const results = await all(a, b)({ id: 1 })
 }*/
 ```
 
+### namedAll
+
+`namedAll` works like the `all` function but receives its constituent functions inside a record with string keys that identify each one. The shape of this record will be preserved for the `data` property in successful results.
+
+The motivation for this is that an object with named fields is often preferable to long tuples, when composing many domain functions.
+
+```ts
+const a = makeDomainFunction(z.object({}))(async () => '1')
+const b = makeDomainFunction(z.object({}))(async () => 2)
+const c = makeDomainFunction(z.object({}))(async () => true)
+
+const results = await namedAll({ a, b, c })({})
+```
+
+For the example above, the result type will be `Result<{ a: string, b: number, c: boolean }>`:
+
+```ts
+{
+  success: true,
+  data: { a: '1', b: 2, c: true },
+  errors: [],
+  inputErrors: [],
+  environmentErrors: [],
+}
+```
+
+As with the `all` function, in case any function fails their errors will be concatenated.
+
+### merge
+
+`merge` works exactly like the `all` function, except __the shape of the result__ is different.
+Instead of returning a tuple, it will return a merged object which is equivalent to:
+```ts
+map(all(a, b, c), mergeObjects)
+```
+
+The resulting data of every domain function will be merged into one object. __This could potentially lead to values of the leftmost functions being overwritten by the rightmost ones__.
+
+```ts
+const a = makeDomainFunction(z.object({}))(async () => ({
+  resultA: 'string',
+  resultB: 'string',
+  resultC: 'string',
+}))
+const b = makeDomainFunction(z.object({}))(async () => ({ resultB: 2 }))
+const c = makeDomainFunction(z.object({}))(async () => ({ resultC: true }))
+
+const results = await merge(a, b, c)({})
+```
+
+For the example above, the result type will be `Result<{ resultA: string, resultB: number, resultC: boolean }>`:
+
+```ts
+{
+  success: true,
+  data: { resultA: 'string', resultB: 2, resultC: true },
+  errors: [],
+  inputErrors: [],
+  environmentErrors: [],
+}
+```
+
+__Be mindful of__ each constituent domain function's return type. If any domain function returns something other than an object, the composite domain function will return an `ErrorResult`:
+
+```ts
+{
+  success: false,
+  errors: [{ message: 'Invalid data format returned from some domain functions' }],
+  inputErrors: [],
+  environmentErrors: [],
+}
+```
+
 ### first
 
 `first` will create a composite domain function that will return the result of the first successful constituent domain function. It handles inputs and environments like the `all` function.
@@ -455,44 +528,6 @@ const result = await first(a, b)({ id: 1 })
   inputErrors: [],
   environmentErrors: [],
 }*/
-```
-
-### merge
-
-`merge` works exactly like the `all` function, except __the shape of the result__ is different.
-Instead of returning a tuple, it will return a merged object.
-
-The motivation for this is that an object with named fields is often preferable to long tuples, when composing many domain functions.
-
-```ts
-const a = makeDomainFunction(z.object({}))(async () => ({ resultA: '1' }))
-const b = makeDomainFunction(z.object({}))(async () => ({ resultB: 2 }))
-const c = makeDomainFunction(z.object({}))(async () => ({ resultC: true }))
-
-const results = await merge(a, b, c)({})
-```
-
-For the example above, the result type will be `Result<{ resultA: string, resultB: number, resultC: boolean }>`:
-
-```ts
-{
-  success: true,
-  data: { resultA: '1', resultB: 2, resultC: true },
-  errors: [],
-  inputErrors: [],
-  environmentErrors: [],
-}
-```
-
-__Be mindful of__ each constituent domain function's return type. If any domain function returns something other than an object, the composite domain function will return an `ErrorResult`:
-
-```ts
-{
-  success: false,
-  errors: [{ message: 'Invalid data format returned from some domain functions' }],
-  inputErrors: [],
-  environmentErrors: [],
-}
 ```
 
 ### pipe

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It does this by enforcing the parameters' types at runtime (through [zod](https:
   - [Tracing](#tracing)
 - [Combining domain functions](#combining-domain-functions)
   - [all](#all)
-  - [namedAll](#namedall)
+  - [collect](#collect)
   - [merge](#merge)
   - [first](#first)
   - [pipe](#pipe)
@@ -389,9 +389,9 @@ const results = await all(a, b)({ id: 1 })
 }*/
 ```
 
-### namedAll
+### collect
 
-`namedAll` works like the `all` function but receives its constituent functions inside a record with string keys that identify each one. The shape of this record will be preserved for the `data` property in successful results.
+`collect` works like the `all` function but receives its constituent functions inside a record with string keys that identify each one. The shape of this record will be preserved for the `data` property in successful results.
 
 The motivation for this is that an object with named fields is often preferable to long tuples, when composing many domain functions.
 
@@ -400,7 +400,7 @@ const a = makeDomainFunction(z.object({}))(async () => '1')
 const b = makeDomainFunction(z.object({}))(async () => 2)
 const c = makeDomainFunction(z.object({}))(async () => true)
 
-const results = await namedAll({ a, b, c })({})
+const results = await collect({ a, b, c })({})
 ```
 
 For the example above, the result type will be `Result<{ a: string, b: number, c: boolean }>`:

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -9,13 +9,13 @@ import { z } from 'https://deno.land/x/zod@v3.19.1/mod.ts'
 
 import {
   all,
-  combine,
   first,
   fromSuccess,
   makeDomainFunction,
   map,
   mapError,
   merge,
+  oldMerge,
   pipe,
   sequence,
   trace,
@@ -420,7 +420,7 @@ describe('all', () => {
   })
 })
 
-describe('combine', () => {
+describe('merge', () => {
   it('should combine an object of domain functions', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => id + 1,
@@ -429,7 +429,7 @@ describe('combine', () => {
       async ({ id }) => id - 1,
     )
 
-    const c: DomainFunction<{ a: number; b: number }> = combine({ a, b })
+    const c: DomainFunction<{ a: number; b: number }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: true,
@@ -448,7 +448,7 @@ describe('combine', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: number; b: string }> = combine({ a, b })
+    const c: DomainFunction<{ a: number; b: string }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -471,7 +471,7 @@ describe('combine', () => {
       throw 'Error'
     })
 
-    const c: DomainFunction<{ a: number; b: never }> = combine({ a, b })
+    const c: DomainFunction<{ a: number; b: never }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -489,7 +489,7 @@ describe('combine', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: string; b: string }> = combine({ a, b })
+    const c: DomainFunction<{ a: string; b: string }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -516,7 +516,7 @@ describe('combine', () => {
       throw new Error('Error B')
     })
 
-    const c: DomainFunction<{ a: never; b: never }> = combine({ a, b })
+    const c: DomainFunction<{ a: never; b: never }> = merge({ a, b })
 
     assertObjectMatch(await c({ id: 1 }), {
       success: false,
@@ -596,7 +596,7 @@ describe('first', () => {
   })
 })
 
-describe('merge', () => {
+describe('oldMerge through merge', () => {
   it('should combine two domain functions results into one object', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => ({ resultA: id + 1 }),

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -15,7 +15,6 @@ import {
   map,
   mapError,
   merge,
-  oldMerge,
   pipe,
   sequence,
   trace,

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -9,13 +9,13 @@ import { z } from 'https://deno.land/x/zod@v3.19.1/mod.ts'
 
 import {
   all,
+  collect,
   first,
   fromSuccess,
   makeDomainFunction,
   map,
   mapError,
   merge,
-  namedAll,
   pipe,
   sequence,
   trace,
@@ -420,7 +420,7 @@ describe('all', () => {
   })
 })
 
-describe('namedAll', () => {
+describe('collect', () => {
   it('should combine an object of domain functions', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => id + 1,
@@ -429,7 +429,7 @@ describe('namedAll', () => {
       async ({ id }) => id - 1,
     )
 
-    const c: DomainFunction<{ a: number; b: number }> = namedAll({ a, b })
+    const c: DomainFunction<{ a: number; b: number }> = collect({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: true,
@@ -448,7 +448,7 @@ describe('namedAll', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: number; b: string }> = namedAll({ a, b })
+    const c: DomainFunction<{ a: number; b: string }> = collect({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -471,7 +471,7 @@ describe('namedAll', () => {
       throw 'Error'
     })
 
-    const c: DomainFunction<{ a: number; b: never }> = namedAll({ a, b })
+    const c: DomainFunction<{ a: number; b: never }> = collect({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -489,7 +489,7 @@ describe('namedAll', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: string; b: string }> = namedAll({ a, b })
+    const c: DomainFunction<{ a: string; b: string }> = collect({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -516,7 +516,7 @@ describe('namedAll', () => {
       throw new Error('Error B')
     })
 
-    const c: DomainFunction<{ a: never; b: never }> = namedAll({ a, b })
+    const c: DomainFunction<{ a: never; b: never }> = collect({ a, b })
 
     assertObjectMatch(await c({ id: 1 }), {
       success: false,

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -15,6 +15,7 @@ import {
   map,
   mapError,
   merge,
+  namedAll,
   pipe,
   sequence,
   trace,
@@ -419,7 +420,7 @@ describe('all', () => {
   })
 })
 
-describe('merge', () => {
+describe('namedAll', () => {
   it('should combine an object of domain functions', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => id + 1,
@@ -428,7 +429,7 @@ describe('merge', () => {
       async ({ id }) => id - 1,
     )
 
-    const c: DomainFunction<{ a: number; b: number }> = merge({ a, b })
+    const c: DomainFunction<{ a: number; b: number }> = namedAll({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: true,
@@ -447,7 +448,7 @@ describe('merge', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: number; b: string }> = merge({ a, b })
+    const c: DomainFunction<{ a: number; b: string }> = namedAll({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -470,7 +471,7 @@ describe('merge', () => {
       throw 'Error'
     })
 
-    const c: DomainFunction<{ a: number; b: never }> = merge({ a, b })
+    const c: DomainFunction<{ a: number; b: never }> = namedAll({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -488,7 +489,7 @@ describe('merge', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: string; b: string }> = merge({ a, b })
+    const c: DomainFunction<{ a: string; b: string }> = namedAll({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -515,7 +516,7 @@ describe('merge', () => {
       throw new Error('Error B')
     })
 
-    const c: DomainFunction<{ a: never; b: never }> = merge({ a, b })
+    const c: DomainFunction<{ a: never; b: never }> = namedAll({ a, b })
 
     assertObjectMatch(await c({ id: 1 }), {
       success: false,
@@ -595,7 +596,7 @@ describe('first', () => {
   })
 })
 
-describe('oldMerge through merge', () => {
+describe('merge', () => {
   it('should combine two domain functions results into one object', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => ({ resultA: id + 1 }),

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -387,7 +387,6 @@ export {
   map,
   mapError,
   merge,
-  oldMerge,
   pipe,
   sequence,
   trace,

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -127,32 +127,9 @@ function all<Fns extends DomainFunction[]>(
   }
 }
 
-function isRecordOfDF(
-  fns: DomainFunction | Record<string, DomainFunction>,
-): fns is Record<string, DomainFunction> {
-  return (
-    typeof fns === 'object' &&
-    Object.values(fns).every((fn) => fn instanceof Function)
-  )
-}
-
-/**
- * @deprecated Using this function with multiple domain function arguments will be removed in 2.0.0.
- * You should give it a single object of type Record<string, DomainFunction> instead.
- */
-function merge<Fn extends DomainFunction, Fns extends DomainFunction[]>(
-  fn: Fn,
-  ...fns: Fns
-): DomainFunction<MergeObjs<UnpackAll<[Fn, ...Fns]>>>
-function merge<Fns extends Record<string, DomainFunction>>(
+function namedAll<Fns extends Record<string, DomainFunction>>(
   fns: Fns,
-): DomainFunction<UnpackDFObject<Fns>>
-function merge<Fns extends DomainFunction | Record<string, DomainFunction>>(
-  fns: Fns,
-  ...rest: unknown[]
-): DomainFunction {
-  if (!isRecordOfDF(fns)) return oldMerge(fns, ...(rest as DomainFunction[]))
-
+): DomainFunction<UnpackDFObject<Fns>> {
   return async (input, environment) => {
     const results = await Promise.all(
       Object.entries(fns).map(
@@ -185,7 +162,7 @@ function merge<Fns extends DomainFunction | Record<string, DomainFunction>>(
       inputErrors: [],
       environmentErrors: [],
       errors: [],
-    } as SuccessResult<UnpackDFObject<typeof fns>>
+    } as SuccessResult<UnpackDFObject<Fns>>
   }
 }
 
@@ -219,7 +196,7 @@ function first<Fns extends DomainFunction[]>(
   }
 }
 
-function oldMerge<Fns extends DomainFunction<Record<string, unknown>>[]>(
+function merge<Fns extends DomainFunction<Record<string, unknown>>[]>(
   ...fns: Fns
 ): DomainFunction<MergeObjs<UnpackAll<Fns>>> {
   return async (input, environment) => {
@@ -387,6 +364,7 @@ export {
   map,
   mapError,
   merge,
+  namedAll,
   pipe,
   sequence,
   trace,

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -127,7 +127,7 @@ function all<Fns extends DomainFunction[]>(
   }
 }
 
-function namedAll<Fns extends Record<string, DomainFunction>>(
+function collect<Fns extends Record<string, DomainFunction>>(
   fns: Fns,
 ): DomainFunction<UnpackDFObject<Fns>> {
   return async (input, environment) => {
@@ -358,13 +358,13 @@ function trace<D extends DomainFunction = DomainFunction<unknown>>(
 
 export {
   all,
+  collect,
   first,
   fromSuccess,
   makeDomainFunction,
   map,
   mapError,
   merge,
-  namedAll,
   pipe,
   sequence,
   trace,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,4 @@
-export {
-  all,
-  first,
-  fromSuccess,
-  makeDomainFunction,
-  map,
-  mapError,
-  merge,
-  pipe,
-  sequence,
-  trace,
-} from './domain-functions.ts'
+export * from './domain-functions.ts'
 export * from './input-resolvers.ts'
 export * from './errors.ts'
 export * from './deprecated-types.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,15 @@
-export * from './domain-functions.ts'
+export {
+  all,
+  first,
+  fromSuccess,
+  makeDomainFunction,
+  map,
+  mapError,
+  merge,
+  pipe,
+  sequence,
+  trace,
+} from './domain-functions.ts'
 export * from './input-resolvers.ts'
 export * from './errors.ts'
 export * from './deprecated-types.ts'

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,10 @@ type UnpackAll<List, output extends unknown[] = []> = List extends [
   ? UnpackAll<rest, [...output, first]>
   : output
 
+type UnpackDFObject<Obj extends Record<string, DomainFunction>> =
+  | { [K in keyof Obj]: UnpackData<Obj[K]> }
+  | never
+
 type MergeObjs<Objs extends unknown[], output = {}> = Prettify<
   Objs extends [infer first, ...infer rest]
     ? MergeObjs<rest, Omit<output, keyof first> & first>
@@ -53,6 +57,7 @@ type MergeObjs<Objs extends unknown[], output = {}> = Prettify<
 
 type Prettify<T> = {
   [K in keyof T]: T[K]
+  // deno-lint-ignore ban-types
 } & {}
 
 type TupleToUnion<T extends unknown[]> = T[number]
@@ -77,6 +82,7 @@ export type {
   TupleToUnion,
   UnpackAll,
   UnpackData,
+  UnpackDFObject,
   UnpackResult,
   UnpackSuccess,
 }


### PR DESCRIPTION
This is not my idea, it was @jly36963 's idea and I loved it.

Still not sure about the name but I think if we had this combinator since the beginning we wouldn't have `merge` or even `all` (... maybe) as this combinator does not enforce an object as a return type of every domain function.

Ideas?