### PR TITLE
Deprecate oldMerge usage and add a function overload to make the new …

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,41 +459,31 @@ const result = await first(a, b)({ id: 1 })
 
 ### merge
 
-`merge` works exactly like the `all` function, except __the shape of the result__ is different.
-Instead of returning a tuple, it will return a merged object.
+`merge` receives an object of domain functions, will run all in parallel and combine their results in the same shape as the given object.
 
 The motivation for this is that an object with named fields is often preferable to long tuples, when composing many domain functions.
 
 ```ts
-const a = makeDomainFunction(z.object({}))(async () => ({ resultA: '1' }))
-const b = makeDomainFunction(z.object({}))(async () => ({ resultB: 2 }))
-const c = makeDomainFunction(z.object({}))(async () => ({ resultC: true }))
+const a = makeDomainFunction(z.object({}))(async () => '1')
+const b = makeDomainFunction(z.object({}))(async () => 2)
+const c = makeDomainFunction(z.object({}))(async () => true)
 
-const results = await merge(a, b, c)({})
+const results = await merge({ a, b, c })({})
 ```
 
-For the example above, the result type will be `Result<{ resultA: string, resultB: number, resultC: boolean }>`:
+For the example above, the result type will be `Result<{ a: string, b: number, c: boolean }>`:
 
 ```ts
 {
   success: true,
-  data: { resultA: '1', resultB: 2, resultC: true },
+  data: { a: '1', b: 2, c: true },
   errors: [],
   inputErrors: [],
   environmentErrors: [],
 }
 ```
 
-__Be mindful of__ each constituent domain function's return type. If any domain function returns something other than an object, the composite domain function will return an `ErrorResult`:
-
-```ts
-{
-  success: false,
-  errors: [{ message: 'Invalid data format returned from some domain functions' }],
-  inputErrors: [],
-  environmentErrors: [],
-}
-```
+As with the `all` function, in case any function fails their errors will be concatenated.
 
 ### pipe
 

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -9,13 +9,13 @@ import { z } from 'https://deno.land/x/zod@v3.19.1/mod.ts'
 
 import {
   all,
-  combine,
   first,
   fromSuccess,
   makeDomainFunction,
   map,
   mapError,
   merge,
+  oldMerge,
   pipe,
   sequence,
   trace,
@@ -420,7 +420,7 @@ describe('all', () => {
   })
 })
 
-describe('combine', () => {
+describe('merge', () => {
   it('should combine an object of domain functions', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => id + 1,
@@ -429,7 +429,7 @@ describe('combine', () => {
       async ({ id }) => id - 1,
     )
 
-    const c: DomainFunction<{ a: number; b: number }> = combine({ a, b })
+    const c: DomainFunction<{ a: number; b: number }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: true,
@@ -448,7 +448,7 @@ describe('combine', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: number; b: string }> = combine({ a, b })
+    const c: DomainFunction<{ a: number; b: string }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -471,7 +471,7 @@ describe('combine', () => {
       throw 'Error'
     })
 
-    const c: DomainFunction<{ a: number; b: never }> = combine({ a, b })
+    const c: DomainFunction<{ a: number; b: never }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -489,7 +489,7 @@ describe('combine', () => {
       async ({ id }) => id,
     )
 
-    const c: DomainFunction<{ a: string; b: string }> = combine({ a, b })
+    const c: DomainFunction<{ a: string; b: string }> = merge({ a, b })
 
     assertEquals(await c({ id: 1 }), {
       success: false,
@@ -516,7 +516,7 @@ describe('combine', () => {
       throw new Error('Error B')
     })
 
-    const c: DomainFunction<{ a: never; b: never }> = combine({ a, b })
+    const c: DomainFunction<{ a: never; b: never }> = merge({ a, b })
 
     assertObjectMatch(await c({ id: 1 }), {
       success: false,
@@ -596,7 +596,7 @@ describe('first', () => {
   })
 })
 
-describe('merge', () => {
+describe('oldMerge through merge', () => {
   it('should combine two domain functions results into one object', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => ({ resultA: id + 1 }),

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -127,9 +127,32 @@ function all<Fns extends DomainFunction[]>(
   }
 }
 
-function combine<Fns extends Record<string, DomainFunction>>(
+function isRecordOfDF(
+  fns: DomainFunction | Record<string, DomainFunction>,
+): fns is Record<string, DomainFunction> {
+  return (
+    typeof fns === 'object' &&
+    Object.values(fns).every((fn) => fn instanceof Function)
+  )
+}
+
+/**
+ * @deprecated Using this function with multiple domain function arguments will be removed in 2.0.0.
+ * You should give it a single object of type Record<string, DomainFunction> instead.
+ */
+function merge<Fn extends DomainFunction, Fns extends DomainFunction[]>(
+  fn: Fn,
+  ...fns: Fns
+): DomainFunction<MergeObjs<UnpackAll<[Fn, ...Fns]>>>
+function merge<Fns extends Record<string, DomainFunction>>(
   fns: Fns,
-): DomainFunction<UnpackDFObject<Fns>> {
+): DomainFunction<UnpackDFObject<Fns>>
+function merge<Fns extends DomainFunction | Record<string, DomainFunction>>(
+  fns: Fns,
+  ...rest: unknown[]
+): DomainFunction {
+  if (!isRecordOfDF(fns)) return oldMerge(fns, ...(rest as DomainFunction[]))
+
   return async (input, environment) => {
     const results = await Promise.all(
       Object.entries(fns).map(
@@ -162,7 +185,7 @@ function combine<Fns extends Record<string, DomainFunction>>(
       inputErrors: [],
       environmentErrors: [],
       errors: [],
-    } as SuccessResult<UnpackDFObject<Fns>>
+    } as SuccessResult<UnpackDFObject<typeof fns>>
   }
 }
 
@@ -196,7 +219,10 @@ function first<Fns extends DomainFunction[]>(
   }
 }
 
-function merge<Fns extends DomainFunction[]>(
+/**
+ * @deprecated This method will be removed in 2.0.0.
+ */
+function oldMerge<Fns extends DomainFunction[]>(
   ...fns: Fns
 ): DomainFunction<MergeObjs<UnpackAll<Fns>>> {
   return async (input, environment) => {
@@ -358,13 +384,13 @@ function trace<D extends DomainFunction = DomainFunction<unknown>>(
 
 export {
   all,
-  combine,
   first,
   fromSuccess,
   makeDomainFunction,
   map,
   mapError,
   merge,
+  oldMerge,
   pipe,
   sequence,
   trace,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,15 @@
-export * from './domain-functions.ts'
+export {
+  all,
+  first,
+  fromSuccess,
+  makeDomainFunction,
+  map,
+  mapError,
+  merge,
+  pipe,
+  sequence,
+  trace,
+} from './domain-functions.ts'
 export * from './input-resolvers.ts'
 export * from './errors.ts'
 export * from './deprecated-types.ts'


### PR DESCRIPTION
…merge the new merge API

As suggested by @diogob in #66 I added an overload to the `merge` function (previously called `combine` in #66).

When using the old api the function will go through the `oldMerge` method.

Also, with the TS deprecation message the DX is as good as expected, you'll see a line-through on the `merge` function when trying to use the old API but every test and type test will keep succeeding.

![tweet2](https://user-images.githubusercontent.com/566971/220181577-0f915133-d715-4911-a80a-ff54ae245a5d.gif)