### PR TITLE
Fix MergeObjs type to behave more like JS's Object.assign and add som…

### DIFF
--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -507,7 +507,11 @@ describe('merge', () => {
 
   it('should combine many domain functions into one', async () => {
     const a = makeDomainFunction(z.object({ id: z.number() }))(
-      async ({ id }) => ({ resultA: String(id) }),
+      async ({ id }) => ({
+        resultA: String(id),
+        resultB: String(id),
+        resultC: String(id),
+      }),
     )
     const b = makeDomainFunction(z.object({ id: z.number() }))(
       async ({ id }) => ({ resultB: id + 1 }),
@@ -524,7 +528,11 @@ describe('merge', () => {
     const results = await d({ id: 1 })
     assertEquals(results, {
       success: true,
-      data: { resultA: '1', resultB: 2, resultC: true },
+      data: {
+        resultA: '1',
+        resultB: 2,
+        resultC: true,
+      },
       errors: [],
       inputErrors: [],
       environmentErrors: [],
@@ -539,7 +547,7 @@ describe('merge', () => {
       async ({ id }) => ({ id }),
     )
 
-    const c: DomainFunction<{ id: number }> = merge(a, b)
+    const c: DomainFunction<{ id: string }> = merge(a, b)
 
     assertEquals(await c({ id: 1 }), {
       success: false,

--- a/src/domain-function.test.ts
+++ b/src/domain-function.test.ts
@@ -636,8 +636,8 @@ describe('merge', () => {
       async ({ id }) => ({ resultB: id - 1 }),
     )
 
-    // @ts-expect-error the inferred type is huge bc it has all properties from the number primitive
-    const c: DomainFunction<number & { resultB: number }> = merge(a, b)
+    // @ts-expect-error - DF a is not DomainFunction<Record<string, unknown>>
+    const c = merge(a, b)
 
     assertEquals(await c({ id: 1 }), {
       success: false,

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -156,7 +156,7 @@ function first<Fns extends DomainFunction[]>(
   }
 }
 
-function merge<Fns extends DomainFunction[]>(
+function merge<Fns extends DomainFunction<Record<string, unknown>>[]>(
   ...fns: Fns
 ): DomainFunction<MergeObjs<UnpackAll<Fns>>> {
   return async (input, environment) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ type UnpackAll<List, output extends unknown[] = []> = List extends [
 
 type MergeObjs<Objs extends unknown[], output = {}> = Prettify<
   Objs extends [infer first, ...infer rest]
-    ? MergeObjs<rest, output & first>
+    ? MergeObjs<rest, Omit<output, keyof first> & first>
     : output
 >
 


### PR DESCRIPTION
…e regression tests.

## Reasoning
There was a mismatch between type and runtime behavior of `mergeObjects` as shown here:
```ts
const a = { a: 1, b: 2 }
const b = { b: true }
const c = mergeObjects([a, b]) // should behave like { ...a, ...b }
//    ˆ?  { a: number, b: never }
```

This PR fixes it according to what we would expect: `{ a: number, b: boolean }`. It also enforces the correct parameter types with TS: `DomainFunction<string, unknown>[]`

This bug was mentioned in #66 