### PR TITLE
Remove prettify to avoid circular bug

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,11 +49,10 @@ type UnpackDFObject<Obj extends Record<string, DomainFunction>> =
   | { [K in keyof Obj]: UnpackData<Obj[K]> }
   | never
 
-type MergeObjs<Objs extends unknown[], output = {}> = Prettify<
+type MergeObjs<Objs extends unknown[], output = {}> =
   Objs extends [infer first, ...infer rest]
-    ? MergeObjs<rest, Omit<output, keyof first> & first>
+    ? MergeObjs<rest, Prettify<Omit<output, keyof first> & first>>
     : output
->
 
 type Prettify<T> = {
   [K in keyof T]: T[K]


### PR DESCRIPTION
This was reported on #81 , the `Prettify` type is supposed to help with readability of resulting type of `MergeObj` but it has a - now - known bug that can cause infinitely recursive types thus killing TSC.

You can read more about it here: https://github.com/remix-run/remix/pull/6736