### PR TITLE
Rewrite collect to leverage simpler combinators

### DIFF
--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -50,7 +50,7 @@ function collect<Fns extends Record<string, DomainFunction>>(
   fns: Fns,
 ): DomainFunction<UnpackDFObject<Fns>> {
   const dfsWithKey = Object.entries(fns).map(([key, df]) =>
-    map(df, (result) => Object.fromEntries([[key, result]])),
+    map(df, (result) => ({ [key]: result })),
   )
   return map(all(...dfsWithKey), mergeObjects) as DomainFunction<UnpackDFObject<Fns>>
 

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -49,40 +49,11 @@ function all<Fns extends DomainFunction[]>(
 function collect<Fns extends Record<string, DomainFunction>>(
   fns: Fns,
 ): DomainFunction<UnpackDFObject<Fns>> {
-  return async (input, environment) => {
-    const results = await Promise.all(
-      Object.entries(fns).map(
-        async ([key, fn]) =>
-          [key, await (fn as DomainFunction)(input, environment)] as const,
-      ),
-    )
+  const dfsWithKey = Object.entries(fns).map(([key, df]) =>
+    map(df, (result) => Object.fromEntries([[key, result]])),
+  )
+  return map(all(...dfsWithKey), mergeObjects) as DomainFunction<UnpackDFObject<Fns>>
 
-    const collectedResults = results.map(([, result]) => result)
-    if (!isListOfSuccess(collectedResults)) {
-      return {
-        success: false,
-        errors: collectedResults.map(({ errors }) => errors).flat(),
-        inputErrors: collectedResults
-          .map(({ inputErrors }) => inputErrors)
-          .flat(),
-        environmentErrors: collectedResults
-          .map(({ environmentErrors }) => environmentErrors)
-          .flat(),
-      }
-    }
-
-    const allData = results.map(([key, result]) => [
-      key,
-      (result as SuccessResult).data,
-    ])
-    return {
-      success: true,
-      data: Object.fromEntries(allData),
-      inputErrors: [],
-      environmentErrors: [],
-      errors: [],
-    } as SuccessResult<UnpackDFObject<Fns>>
-  }
 }
 
 function first<Fns extends DomainFunction[]>(


### PR DESCRIPTION
It seems that `collect` could easily be expressed in terms of `all`.
The parallel application is the same, and we just need to push the keys from the input to the output.

This ensures we never have issues with the output shave as we do in the `merge` combinator.
