### PR TITLE
Add README note steering users away from merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ Instead of returning a tuple, it will return a merged object which is equivalent
 map(all(a, b, c), mergeObjects)
 ```
 
+**NOTE :** Try to use [collect](collect) instead wherever possible since it is much safer. `merge` can create domain functions that will always fail in run-time or even overwrite data from successful constituent functions application. The `collect` function does not have these issues and serves a similar purpose.
+
 The resulting data of every domain function will be merged into one object. __This could potentially lead to values of the leftmost functions being overwritten by the rightmost ones__.
 
 ```ts


### PR DESCRIPTION
I do not like having partial functions in the same namespace as all the others.
I would leve to move `merge` to another module called `unsafe` or `partial`, or perhaps even deprecate the combinator for future removal.

For now I'm happy just telling visitors to steer clear.
