### PR TITLE
Removes runtime validation from merge to make its definition shorter

### DIFF
--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -1,5 +1,3 @@
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
-
 import { ResultError } from './errors.ts'
 import { isListOfSuccess, mergeObjects } from './utils.ts'
 import type {
@@ -121,13 +119,7 @@ function first<Fns extends DomainFunction[]>(
 function merge<Fns extends DomainFunction<Record<string, unknown>>[]>(
   ...fns: Fns
 ): DomainFunction<MergeObjs<UnpackAll<Fns>>> {
-  return map(all(...fns), (results) => {
-    const resultSchema = z.record(z.any())
-    if (results.some((r) => resultSchema.safeParse(r).success === false)) {
-      throw new Error('Invalid data format returned from some domainFunction')
-    }
-    return mergeObjects(results)
-  })
+  return map(all(...fns), mergeObjects)
 }
 
 /**

--- a/src/merge.test.ts
+++ b/src/merge.test.ts
@@ -172,25 +172,4 @@ describe('merge', () => {
       environmentErrors: [],
     })
   })
-
-  it('should throw an error when the results of some domain functions are not objects', async () => {
-    const a = makeDomainFunction(z.object({ id: z.number() }))(
-      ({ id }) => id + 1,
-    )
-    const b = makeDomainFunction(z.object({ id: z.number() }))(({ id }) => ({
-      resultB: id - 1,
-    }))
-
-    // @ts-expect-error - DF a is not DomainFunction<Record<string, unknown>>
-    const c = merge(a, b)
-
-    assertObjectMatch(await c({ id: 1 }), {
-      success: false,
-      errors: [
-        { message: 'Invalid data format returned from some domainFunction' },
-      ],
-      inputErrors: [],
-      environmentErrors: [],
-    })
-  })
 })


### PR DESCRIPTION
On the path to v2 we decided to keep the `merge` function in the lib with all due warnings.
This will avoid breaking changes.

I removed the runtime validation from the function definition to make it as thin as we think it should be.
It shouldn't add any runtime changes as the validation would be already throwing in case the `merged` was misued. ;)

Important to notice the TS type check will still enforce the correct usage as the parameters must extend `DomainFunction<Record<string, unknown>>`.