### PR TITLE
Adds identity and passthrough to the combinators

### DIFF
--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -336,6 +336,21 @@ function trace<D extends DomainFunction = DomainFunction<unknown>>(
   }
 }
 
+// deno-lint-ignore no-explicit-any
+const makeSuccess = (input?: any) =>
+  ({
+    success: true,
+    data: input,
+    inputErrors: [],
+    errors: [],
+    environmentErrors: [],
+    // deno-lint-ignore no-explicit-any
+  } as any)
+
+const passthrough = <T extends DomainFunction<Record<string, unknown>>>(
+  df: T,
+) => map(all(df, makeSuccess), mergeObjects)
+
 export {
   all,
   branch,
@@ -349,4 +364,5 @@ export {
   pipe,
   sequence,
   trace,
+  passthrough
 }


### PR DESCRIPTION
As discussed in #86 , sometimes it is good to have `identity` function to help on compositions.

I also suggested the `passthrough` which is a shortcut for `map(all(myDf, identity), mergeObjects)` and will probably be used whenever someone wants a domain-function to forward all the received input to the next df in the composition.

I'll keep this PR as a draft until I write proper tests and docs for it.

The plan is to ship it on v2.