### PR TITLE
feat: Adds a `collectSequence` combinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,12 +614,12 @@ This feature relies on JS's order of objects' keys (guaranteed since ECMAScript2
 const a = makeDomainFunction(z.number())((aNumber) => String(aNumber))
 const b = makeDomainFunction(z.string())((aString) => aString === '1')
 
-const c = collectSequence({a, b})
+const c = collectSequence({ a, b })
 
 const result = await c(1)
 ```
 
-For the example above, the result type will be `Result<{ a: string, b: boolean}>`:
+For the example above, the result type will be `Result<{ a: string, b: boolean }>`:
 
 ```ts
 {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It does this by enforcing the parameters' types at runtime (through [zod](https:
   - [pipe](#pipe)
   - [branch](#branch)
   - [sequence](#sequence)
-  - [collectSequence](#collectSequence)
+  - [collectSequence](#collectsequence)
   - [map](#map)
   - [mapError](#maperror)
 - [Runtime utilities](#runtime-utilities)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It does this by enforcing the parameters' types at runtime (through [zod](https:
   - [pipe](#pipe)
   - [branch](#branch)
   - [sequence](#sequence)
+  - [collectSequence](#collectSequence)
   - [map](#map)
   - [mapError](#maperror)
 - [Runtime utilities](#runtime-utilities)
@@ -597,6 +598,58 @@ const result = await c(1)
 ```
 
 For the example above, the result type will be `Result<{ aString: string, aBoolean: boolean }>`.
+
+### collectSequence
+
+`collectSequence` is very similar to the `collect` function, except __it runs in the sequence of the keys' order like a `pipe`__.
+
+It receives its constituent functions inside a record with string keys that identify each one. 
+The shape of this record will be preserved for the `data` property in successful results.
+
+This feature relies on JS's order of objects' keys (guaranteed since ECMAScript2015).
+
+**NOTE :** For number-like object keys (eg: { 2: dfA, 1: dfB }) JS will follow ascendent order.
+
+```ts
+const a = makeDomainFunction(z.number())((aNumber) => String(aNumber))
+const b = makeDomainFunction(z.string())((aString) => aString === '1')
+
+const c = collectSequence({a, b})
+
+const result = await c(1)
+```
+
+For the example above, the result type will be `Result<{ a: string, b: boolean}>`:
+
+```ts
+{
+  success: true,
+  data: { a: '1', b: true },
+  errors: [],
+  inputErrors: [],
+  environmentErrors: [],
+}
+```
+
+If you'd rather have an object instead of a tuple (similar to the `merge` function), you can use the `map` and `mergeObjects` functions like so:
+
+```ts
+import { mergeObjects } from 'domain-functions'
+
+const a = makeDomainFunction(z.number())((aNumber) => ({
+  aString: String(aNumber)
+}))
+const b = makeDomainFunction(z.object({ aString: z.string() }))(
+  ({ aString }) => ({ aBoolean: aString === '1' })
+)
+
+const c = map(sequence(a, b), mergeObjects)
+
+const result = await c(1)
+```
+
+For the example above, the result type will be `Result<{ aString: string, aBoolean: boolean }>`.
+
 
 ### branch
 

--- a/src/collect-sequence.test.ts
+++ b/src/collect-sequence.test.ts
@@ -1,0 +1,176 @@
+import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
+import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
+import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+
+import { makeDomainFunction } from './constructor.ts'
+import { collectSequence } from './domain-functions.ts'
+import type { DomainFunction } from './types.ts'
+import type { Equal, Expect } from './types.test.ts'
+
+describe('collectSequence', () => {
+  it('should compose domain functions keeping the given order of keys', async () => {
+    const a = makeDomainFunction(z.object({ id: z.number() }))(({ id }) => ({
+      id: id + 2,
+    }))
+    const b = makeDomainFunction(z.object({ id: z.number() }))(
+      ({ id }) => id - 1,
+    )
+
+    const c = collectSequence({ a, b })
+    type _R = Expect<
+      Equal<typeof c, DomainFunction<{ a: { id: number }; b: number }>>
+    >
+
+    assertEquals(await c({ id: 1 }), {
+      success: true,
+      data: { a: { id: 3 }, b: 2 },
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [],
+    })
+  })
+
+  it('should use the same environment in all composed functions', async () => {
+    const a = makeDomainFunction(
+      z.undefined(),
+      z.object({ env: z.number() }),
+    )((_input, { env }) => ({
+      inp: env + 2,
+    }))
+    const b = makeDomainFunction(
+      z.object({ inp: z.number() }),
+      z.object({ env: z.number() }),
+    )(({ inp }, { env }) => inp + env)
+
+    const c = collectSequence({ a, b })
+    type _R = Expect<
+      Equal<typeof c, DomainFunction<{ a: { inp: number }; b: number }>>
+    >
+
+    assertEquals(await c(undefined, { env: 1 }), {
+      success: true,
+      data: { a: { inp: 3 }, b: 4 },
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [],
+    })
+  })
+
+  it('should fail on the first environment parser failure', async () => {
+    const envParser = z.object({ env: z.number() })
+    const a = makeDomainFunction(
+      z.undefined(),
+      envParser,
+    )((_input, { env }) => ({
+      inp: env + 2,
+    }))
+    const b = makeDomainFunction(
+      z.object({ inp: z.number() }),
+      envParser,
+    )(({ inp }, { env }) => inp + env)
+
+    const c = collectSequence({ a, b })
+    type _R = Expect<
+      Equal<typeof c, DomainFunction<{ a: { inp: number }; b: number }>>
+    >
+
+    assertEquals(await c(undefined, {}), {
+      success: false,
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [{ message: 'Required', path: ['env'] }],
+    })
+  })
+
+  it('should fail on the first input parser failure', async () => {
+    const firstInputParser = z.undefined()
+
+    const a = makeDomainFunction(
+      firstInputParser,
+      z.object({ env: z.number() }),
+    )((_input, { env }) => ({
+      inp: env + 2,
+    }))
+    const b = makeDomainFunction(
+      z.object({ inp: z.number() }),
+      z.object({ env: z.number() }),
+    )(({ inp }, { env }) => inp + env)
+
+    const c = collectSequence({ a, b })
+    type _R = Expect<
+      Equal<typeof c, DomainFunction<{ a: { inp: number }; b: number }>>
+    >
+
+    assertEquals(await c({ inp: 'some invalid input' }, { env: 1 }), {
+      success: false,
+      errors: [],
+      inputErrors: [
+        { message: 'Expected undefined, received object', path: [] },
+      ],
+      environmentErrors: [],
+    })
+  })
+
+  it('should fail on the second input parser failure', async () => {
+    const a = makeDomainFunction(
+      z.undefined(),
+      z.object({ env: z.number() }),
+    )(() => ({
+      inp: 'some invalid input',
+    }))
+    const b = makeDomainFunction(
+      z.object({ inp: z.number() }),
+      z.object({ env: z.number() }),
+    )(({ inp }, { env }) => inp + env)
+
+    const c = collectSequence({ a, b })
+    type _R = Expect<
+      Equal<typeof c, DomainFunction<{ a: { inp: string }; b: number }>>
+    >
+
+    assertEquals(await c(undefined, { env: 1 }), {
+      success: false,
+      errors: [],
+      inputErrors: [
+        { message: 'Expected number, received string', path: ['inp'] },
+      ],
+      environmentErrors: [],
+    })
+  })
+
+  it('should compose more than 2 functions', async () => {
+    const a = makeDomainFunction(z.object({ aNumber: z.number() }))(
+      ({ aNumber }) => ({
+        aString: String(aNumber),
+      }),
+    )
+    const b = makeDomainFunction(z.object({ aString: z.string() }))(
+      ({ aString }) => ({
+        aBoolean: aString == '1',
+      }),
+    )
+    const c = makeDomainFunction(z.object({ aBoolean: z.boolean() }))(
+      ({ aBoolean }) => !aBoolean,
+    )
+
+    const d = collectSequence({ a, b, c })
+    type _R = Expect<
+      Equal<
+        typeof d,
+        DomainFunction<{
+          a: { aString: string }
+          b: { aBoolean: boolean }
+          c: boolean
+        }>
+      >
+    >
+
+    assertEquals(await d({ aNumber: 1 }), {
+      success: true,
+      data: { a: { aString: '1' }, b: { aBoolean: true }, c: false },
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [],
+    })
+  })
+})


### PR DESCRIPTION
For v2 we are adding a `collectSequence` combinator, which has the same API as `collect` but it runs sequentially like `pipe` instead of in parallel.

This feature relies on JS's capability to keep the order of keys of a given object which is true since ECMAScript2015.
For number-like object keys (eg: `{ 2: dfA, 1: dfB }`) JS will follow ascendent order though but we can solve that with docs and warnings.

Still missing docs to merge this PR ;)