### PR TITLE
feat: Support other schema validation libs

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -190,5 +190,21 @@
     "https://jspm.dev/npm:qs@6.9.6/lib/parse!cjs": "b0c4597386bda8cf9de8af3aa98e0a65f5a309f9c8c81b7c5f7979c7de4839b6",
     "https://jspm.dev/npm:qs@6.9.6/lib/stringify!cjs": "7ed83e3ca52ebb09dbf98d86dac970293e1637aa75d27693306dd8a3dd36c353",
     "https://jspm.dev/qs@6.9.6": "7801d7fd6a481b6973a8b4688ec74a5b9641b6623de93b4e85e953c2c884881e"
+  },
+  "npm": {
+    "specifiers": {
+      "@decs/typeschema@0.9.1": "@decs/typeschema@0.9.1",
+      "zod@3.21.4": "zod@3.21.4"
+    },
+    "packages": {
+      "@decs/typeschema@0.9.1": {
+        "integrity": "sha512-ikzD68ViSorw8ad8KvmgDXDmK9ZappOtwis7z87l3357PU/vCgh/2a574jkoNGlT2zmMwzYnj8fAmEdN/idGXw==",
+        "dependencies": {}
+      },
+      "zod@3.21.4": {
+        "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+        "dependencies": {}
+      }
+    }
   }
 }

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -15,11 +15,6 @@ await build({
     undici: true,
   },
   mappings: {
-    'https://deno.land/x/zod@v3.21.4/mod.ts': {
-      name: 'zod',
-      version: '^3.21.4',
-      peerDependency: true,
-    },
     'https://deno.land/x/deno_qs@0.0.1/mod.ts': {
       name: 'qs',
       version: '^6.10.3',

--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertObjectMatch,
 } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { all } from './domain-functions.ts'

--- a/src/branch.test.ts
+++ b/src/branch.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertObjectMatch,
 } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { branch, pipe, all } from './domain-functions.ts'

--- a/src/collect.test.ts
+++ b/src/collect.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertObjectMatch,
 } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { collect } from './domain-functions.ts'

--- a/src/constructor.test.ts
+++ b/src/constructor.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertObjectMatch,
 } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import {

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -1,5 +1,3 @@
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
-
 import { ResultError } from './errors.ts'
 import { isListOfSuccess, mergeObjects } from './utils.ts'
 import type {
@@ -122,8 +120,7 @@ function merge<Fns extends DomainFunction<Record<string, unknown>>[]>(
   ...fns: Fns
 ): DomainFunction<MergeObjs<UnpackAll<Fns>>> {
   return map(all(...fns), (results) => {
-    const resultSchema = z.record(z.any())
-    if (results.some((r) => resultSchema.safeParse(r).success === false)) {
+    if (results.some((r) => typeof r !== 'object')) {
       throw new Error('Invalid data format returned from some domainFunction')
     }
     return mergeObjects(results)

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.117.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import type { Schema as AnySchema, Infer } from 'npm:@decs/typeschema@0.9.1'
 import type {
   ErrorWithMessage,
   SchemaError,
@@ -63,11 +63,11 @@ type NestedErrors<SchemaType> = {
   [Property in keyof SchemaType]: string[] | NestedErrors<SchemaType[Property]>
 }
 
-function errorMessagesForSchema<T extends z.ZodTypeAny>(
+function errorMessagesForSchema<T extends AnySchema>(
   errors: SchemaError[],
   _schema: T,
-): NestedErrors<z.infer<T>> {
-  type SchemaType = z.infer<T>
+): NestedErrors<Infer<T>> {
+  type SchemaType = Infer<T>
   type ErrorObject = { path: string[]; messages: string[] }
 
   const nest = (

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { first } from './domain-functions.ts'

--- a/src/from-success.test.ts
+++ b/src/from-success.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertRejects,
 } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { fromSuccess } from './domain-functions.ts'

--- a/src/map-error.test.ts
+++ b/src/map-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { mapError } from './domain-functions.ts'

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { map } from './domain-functions.ts'

--- a/src/merge.test.ts
+++ b/src/merge.test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertObjectMatch,
 } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { merge } from './domain-functions.ts'

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { pipe } from './domain-functions.ts'

--- a/src/sequence.test.ts
+++ b/src/sequence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { sequence } from './domain-functions.ts'

--- a/src/trace.test.ts
+++ b/src/trace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'https://deno.land/std@0.156.0/testing/bdd.ts'
 import { assertEquals } from 'https://deno.land/std@0.160.0/testing/asserts.ts'
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import { z } from 'npm:zod@3.21.4'
 
 import { makeDomainFunction } from './constructor.ts'
 import { fromSuccess, trace } from './domain-functions.ts'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
-import { z } from 'https://deno.land/x/zod@v3.21.4/mod.ts'
+import type { ValidationIssue } from 'npm:@decs/typeschema@0.9.1'
 
 import type { MergeObjs, Result, SchemaError, SuccessResult } from './types.ts'
 
-function formatSchemaErrors(errors: z.ZodIssue[]): SchemaError[] {
+function formatSchemaErrors(errors: ValidationIssue[]): SchemaError[] {
   return errors.map((error) => {
     const { path, message } = error
-    return { path: path.map(String), message }
+    return { path: (path ?? []).map(String), message }
   })
 }
 
@@ -29,4 +29,24 @@ function mergeObjects<T extends unknown[] = unknown[]>(objs: T) {
   return Object.assign({}, ...objs) as MergeObjs<T>
 }
 
-export { formatSchemaErrors, mergeObjects, isListOfSuccess }
+function assertObject(data: unknown): object {
+  if (data == null || typeof data !== 'object') {
+    throw new Error('Expected an object')
+  }
+  return data
+}
+
+function assertUndefined(data: unknown): undefined {
+  if (data !== undefined) {
+    throw new Error('Expected undefined')
+  }
+  return data
+}
+
+export {
+  formatSchemaErrors,
+  mergeObjects,
+  isListOfSuccess,
+  assertObject,
+  assertUndefined,
+}


### PR DESCRIPTION
Fixes #78

This PR decouples from `zod` by leveraging `typeschema` and allows using any major schema validation lib (`typia`, `valibot`, `arktype`, etc)

Ran both `deno test` and `deno task build-npm` and all tests passed

As requested, this PR doesn't touch tests or README