### PR TITLE
Expose and add JSDocs to `safeResult`

### DIFF
--- a/src/constructor.ts
+++ b/src/constructor.ts
@@ -10,6 +10,25 @@ import { schemaError, toErrorWithMessage } from './errors.ts'
 import { formatSchemaErrors } from './utils.ts'
 import type { DomainFunction, Result } from './types.ts'
 
+/**
+ * A functions that turns the result of its callback into a Result object.
+ * @example
+ * const result = await safeResult(() => ({
+ *   message: 'hello',
+ * }))
+ * // the type of result is Result<{ message: string }>
+ * if (result.success) {
+ *   console.log(result.data.message)
+ * }
+ *
+ * const result = await safeResult(() => {
+ *  throw new Error('something went wrong')
+ * })
+ * // the type of result is Result<never>
+ * if (!result.success) {
+ *  console.log(result.errors[0].message)
+ * }
+ */
 async function safeResult<T>(fn: () => T): Promise<Result<T>> {
   try {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { makeDomainFunction } from './constructor.ts'
+export { makeDomainFunction, safeResult } from './constructor.ts'
 export * from './domain-functions.ts'
 export * from './input-resolvers.ts'
 export * from './errors.ts'


### PR DESCRIPTION
In order to create our own combinators in our projects to test them before bringing to this repo we will need to expose this function which is used in every combinator.

I added some JSDocs to help whoever decides to hack with domain-functions but not gonna add it to the README yet.