### PR TITLE
Improved `branch` method to act like conditional `pipe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ For the example above, the result type will be `Result<{ aString: string, aBoole
 
 Use `branch` to add conditional logic to your domain functions' compositions.
 
-It receives a domain function and a predicate function that should return the next domain function to be executed based on the previous domain function's output.
+It receives a domain function and a predicate function that should return the next domain function to be executed based on the previous domain function's output, like `pipe`.
 
 ```ts
 const getIdOrEmail = mdf(z.object({ id: z.number().optional, email: z.string().optional() }))((data) => {
@@ -684,6 +684,14 @@ For the example above, the result type will be `Result<User>`:
   environmentErrors: [],
 }
 ```
+If you don't want to pipe when a certain condition is matched, you can return `null` like so:
+```ts
+const a = mdf()(() => 'a')
+const b = mdf()(() => 'b')
+const df = branch(a, (output) => output === 'a' ? null : b)
+//    ^? DomainFunction<'a' | 'b'>
+```
+
 If any function fails, execution halts and the error is returned.
 The predicate function will return an `ErrorResult` type in case it throws:
 ```ts

--- a/src/branch.test.ts
+++ b/src/branch.test.ts
@@ -50,13 +50,11 @@ describe('branch', () => {
   })
 
   it('should not pipe if the predicate returns null', async () => {
-    const a = makeDomainFunction(z.object({ id: z.number() }))(({ id }) => ({
+    const a = mdf(z.object({ id: z.number() }))(({ id }) => ({
       id: id + 2,
       next: 'multiply',
     }))
-    const b = makeDomainFunction(z.object({ id: z.number() }))(({ id }) =>
-      String(id),
-    )
+    const b = mdf(z.object({ id: z.number() }))(({ id }) => String(id))
     const d = branch(a, (output) => (output.next === 'multiply' ? null : b))
     type _R = Expect<
       Equal<typeof d, DomainFunction<string | { id: number; next: string }>>

--- a/src/branch.test.ts
+++ b/src/branch.test.ts
@@ -49,6 +49,28 @@ describe('branch', () => {
     })
   })
 
+  it('should not pipe if the predicate returns null', async () => {
+    const a = makeDomainFunction(z.object({ id: z.number() }))(({ id }) => ({
+      id: id + 2,
+      next: 'multiply',
+    }))
+    const b = makeDomainFunction(z.object({ id: z.number() }))(({ id }) =>
+      String(id),
+    )
+    const d = branch(a, (output) => (output.next === 'multiply' ? null : b))
+    type _R = Expect<
+      Equal<typeof d, DomainFunction<string | { id: number; next: string }>>
+    >
+
+    assertEquals(await d({ id: 1 }), {
+      success: true,
+      data: { id: 3, next: 'multiply' },
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [],
+    })
+  })
+
   it('should use the same environment in all composed functions', async () => {
     const a = mdf(
       z.undefined(),
@@ -122,6 +144,7 @@ describe('branch', () => {
     const b = mdf(z.object({ id: z.number() }))(({ id }) => id - 1)
     const c = branch(a, (_) => {
       throw new Error('condition function failed')
+      // deno-lint-ignore no-unreachable
       return b
     })
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>


### PR DESCRIPTION
This PR adds the possibility to return `null` from a `branch` compinator's predicate so it won't pipe and will follow on with the result of the first DF.

This is a non-breaking change to the already existent `branch` as you can see even the types are preserved.
It will only add the type of the first DF to the possible output if the predicate returns null in the conditional return.

The motivation for this PR is that I've tried to come up with other ways to do it with a combination of `branch` and a `passthrough`. But I always ended up breaking the inference with `passthrough` and with this addition the inference is preserved.