### PR TITLE
feat: Add async capabilities for the trace function

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,9 @@ traceToConsole(someOtherDomainFunction)()
 It would also be simple to create a function that will send the errors to some error tracking service under certain conditions:
 
 ```ts
-const trackErrors = trace(({ input, output, result }) => {
+const trackErrors = trace(async ({ input, output, result }) => {
   if(!result.success && someOtherConditions(result)) {
-    sendToExternalService({ input, output, result })
+    await sendToExternalService({ input, output, result })
   }
 })
 ```

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -339,11 +339,15 @@ type TraceData<T> = {
  * //    ^? DomainFunction<number>
  */
 function trace<D extends DomainFunction = DomainFunction<unknown>>(
-  traceFn: ({ input, environment, result }: TraceData<UnpackResult<D>>) => void,
+  traceFn: ({
+    input,
+    environment,
+    result,
+  }: TraceData<UnpackResult<D>>) => Promise<void> | void,
 ): <T>(fn: DomainFunction<T>) => DomainFunction<T> {
   return (fn) => async (input, environment) => {
     const result = await fn(input, environment)
-    traceFn({ input, environment, result } as TraceData<UnpackResult<D>>)
+    await traceFn({ input, environment, result } as TraceData<UnpackResult<D>>)
     return result
   }
 }


### PR DESCRIPTION
I'm adding `async` capabilities to the `trace` function because "why not" 😎 