### PR TITLE
Fix double decoding URIError when using input resolvers

### DIFF
--- a/src/input-resolvers.test.ts
+++ b/src/input-resolvers.test.ts
@@ -23,6 +23,15 @@ const makeGet: (entries: Array<[string, string]>, url?: string) => Request = (
   })
 
 describe('inputFromForm', () => {
+  it('should parse all symbols correctly', async () => {
+    const request = makePost([
+      ['formula', '3 % 2']
+    ])
+    assertEquals(await subject.inputFromForm(request), {
+      formula: '3 % 2'
+    })
+  })
+
   it("extracts the input values from a Request's FormData as an Object", async () => {
     const request = makePost([
       ['foo', 'bar'],
@@ -247,7 +256,7 @@ describe('inputFromSearch', () => {
   it('takes keys encoded as URI components', () => {
     const qs = new URLSearchParams()
     qs.append('some%20colors[0]', 'blue')
-    qs.append('some%20colors[1]', 'red%20ish')
+    qs.append('some%20colors[1]', 'red ish')
     assertEquals(subject.inputFromSearch(qs), {
       'some colors': ['blue', 'red ish'],
     })
@@ -256,8 +265,8 @@ describe('inputFromSearch', () => {
   it('takes values encoded as URI components', () => {
     const qs = new URLSearchParams()
     qs.append('colors[0]', 'blue')
-    qs.append('colors[1]', 'red%20ish')
-    qs.append('person[name]', 'Average%20Joe')
+    qs.append('colors[1]', 'red ish')
+    qs.append('person[name]', 'Average Joe')
     assertEquals(subject.inputFromSearch(qs), {
       colors: ['blue', 'red ish'],
       person: { name: 'Average Joe' },

--- a/src/input-resolvers.test.ts
+++ b/src/input-resolvers.test.ts
@@ -255,8 +255,8 @@ describe('inputFromSearch', () => {
 
   it('takes keys encoded as URI components', () => {
     const qs = new URLSearchParams()
-    qs.append('some%20colors[0]', 'blue')
-    qs.append('some%20colors[1]', 'red ish')
+    qs.append('some colors[0]', 'blue')
+    qs.append('some colors[1]', 'red ish')
     assertEquals(subject.inputFromSearch(qs), {
       'some colors': ['blue', 'red ish'],
     })

--- a/src/input-resolvers.ts
+++ b/src/input-resolvers.ts
@@ -28,8 +28,7 @@ const inputFromSearch = (queryString: URLSearchParams) => {
 
   return pairs
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-    .reduce((parsed, [encodedKey, value]) => {
-      const key = decodeURIComponent(encodedKey)
+    .reduce((parsed, [key, value]) => {
       const compositeKey = key.match(/([^\[\]]*)(\[.*\].*)$/)
       if (compositeKey) {
         const [, rootKey, subKeys] = compositeKey

--- a/src/input-resolvers.ts
+++ b/src/input-resolvers.ts
@@ -28,9 +28,8 @@ const inputFromSearch = (queryString: URLSearchParams) => {
 
   return pairs
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-    .reduce((parsed, [encodedKey, encodedValue]) => {
+    .reduce((parsed, [encodedKey, value]) => {
       const key = decodeURIComponent(encodedKey)
-      const value = decodeURIComponent(encodedValue)
       const compositeKey = key.match(/([^\[\]]*)(\[.*\].*)$/)
       if (compositeKey) {
         const [, rootKey, subKeys] = compositeKey


### PR DESCRIPTION
We had an unnecessary `decodeURIComponent` for values passed in forms or search parameters.
The error was introduced during our qs replacement in v2.0.0
This PR should take care of #117
