### PR TITLE
Tight composition types

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "publish": "deno task build-npm && cd npm/ && npm publish",
     "build-npm": "deno run -A scripts/build-npm.ts",
     "docs": "deno doc --html --name='domain-functions' ./mod.ts"
-  }
+  },
   "lint": {
     "include": ["src/"],
     "rules": {

--- a/deno.json
+++ b/deno.json
@@ -6,4 +6,10 @@
     "build-npm": "deno run -A scripts/build-npm.ts",
     "docs": "deno doc --html --name='domain-functions' ./mod.ts"
   }
+  "lint": {
+    "include": ["src/"],
+    "rules": {
+      "exclude": ["no-explicit-any", "ban-types"]
+    }
+  }
 }

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -1,4 +1,4 @@
-import { toErrorWithMessage } from "./errors.ts";
+import { toErrorWithMessage } from './errors.ts'
 import {
   AllArguments,
   CollectArguments,
@@ -15,7 +15,7 @@ import {
   Success,
   UnpackAll,
   UnpackResult,
-} from "./types.ts";
+} from './types.ts'
 
 /**
  * Merges a list of objects into a single object.
@@ -30,15 +30,15 @@ import {
  * //   ^? { a: number, b: number, c: number, d: number }
  */
 function mergeObjects<T extends unknown[] = unknown[]>(objs: T) {
-  return Object.assign({}, ...objs) as MergeObjs<T>;
+  return Object.assign({}, ...objs) as MergeObjs<T>
 }
 
 function success<T>(data: T): Success<T> {
-  return { success: true, data, errors: [] };
+  return { success: true, data, errors: [] }
 }
 
 function error(errors: ErrorWithMessage[]): Failure {
-  return { success: false, errors };
+  return { success: false, errors }
 }
 
 /**
@@ -50,12 +50,12 @@ function composable<T extends Fn>(fn: T): Composable<T> {
   return async (...args) => {
     try {
       // deno-lint-ignore no-explicit-any
-      const result = await fn(...(args as any[]));
-      return success(result);
+      const result = await fn(...(args as any[]))
+      return success(result)
     } catch (e) {
-      return error([toErrorWithMessage(e)]);
+      return error([toErrorWithMessage(e)])
     }
-  };
+  }
 }
 
 /**
@@ -79,9 +79,9 @@ function pipe<T extends [Composable, ...Composable[]]>(
     //@ts-ignore pipe uses exactly he same generic input type as sequence
     //           I don't understand what is the issue here but ignoring the errors
     //           is safe and much nicer than a bunch of casts to any
-    const res = (await sequence(...fns)(...args)) as Result<unknown[]>;
-    return !res.success ? error(res.errors) : success(res.data.at(-1));
-  }) as PipeReturn<T>;
+    const res = (await sequence(...fns)(...args)) as Result<unknown[]>
+    return !res.success ? error(res.errors) : success(res.data.at(-1))
+  }) as PipeReturn<T>
 }
 
 /**
@@ -99,18 +99,18 @@ function all<T extends [Composable, ...Composable[]]>(
   ...fns: T & AllArguments<T>
 ) {
   return (async (...args: any) => {
-    const results = await Promise.all(fns.map((fn) => fn(...args)));
+    const results = await Promise.all(fns.map((fn) => fn(...args)))
 
     if (results.some(({ success }) => success === false)) {
-      return error(results.map(({ errors }) => errors).flat());
+      return error(results.map(({ errors }) => errors).flat())
     }
 
-    return success((results as Success<any>[]).map(({ data }) => data));
+    return success((results as Success<any>[]).map(({ data }) => data))
   }) as Composable<
     (...args: Parameters<AllArguments<T>[0]>) => {
-      [key in keyof T]: UnpackResult<ReturnType<Extract<T[key], Composable>>>;
+      [key in keyof T]: UnpackResult<ReturnType<Extract<T[key], Composable>>>
     }
-  >;
+  >
 }
 
 /**
@@ -127,13 +127,13 @@ function collect<T extends Record<string, Composable>>(
   fns: T & CollectArguments<T>,
 ) {
   const fnsWithKey = Object.entries(fns).map(([key, cf]) =>
-    map(cf, (result) => ({ [key]: result }))
-  );
+    map(cf, (result) => ({ [key]: result })),
+  )
   return map(all(...(fnsWithKey as any)), mergeObjects) as Composable<
     (...args: Parameters<AllArguments<RecordToTuple<T>>[0]>) => {
-      [key in keyof T]: UnpackResult<ReturnType<Extract<T[key], Composable>>>;
+      [key in keyof T]: UnpackResult<ReturnType<Extract<T[key], Composable>>>
     }
-  >;
+  >
 }
 
 /**
@@ -150,21 +150,21 @@ function sequence<T extends [Composable, ...Composable[]]>(
   ...fns: T & PipeArguments<T>
 ) {
   return (async (...args) => {
-    const [head, ...tail] = fns as T;
+    const [head, ...tail] = fns as T
 
-    const res = await head(...args);
-    if (!res.success) return error(res.errors);
+    const res = await head(...args)
+    if (!res.success) return error(res.errors)
 
-    const result = [res.data];
+    const result = [res.data]
     for await (const fn of tail) {
-      const res = await fn(result.at(-1));
-      if (!res.success) return error(res.errors);
-      result.push(res.data);
+      const res = await fn(result.at(-1))
+      if (!res.success) return error(res.errors)
+      result.push(res.data)
     }
-    return success(result);
+    return success(result)
   }) as Composable<
     (...args: Parameters<Extract<First<T>, Composable>>) => UnpackAll<T>
-  >;
+  >
 }
 
 /**
@@ -181,12 +181,12 @@ function map<T extends Composable, R>(
   mapper: (res: UnpackResult<ReturnType<T>>) => R,
 ) {
   return (async (...args) => {
-    const res = await fn(...args);
-    if (!res.success) return error(res.errors);
-    const mapped = await composable(mapper)(res.data);
-    if (!mapped.success) return error(mapped.errors);
-    return mapped;
-  }) as Composable<(...args: Parameters<T>) => R>;
+    const res = await fn(...args)
+    if (!res.success) return error(res.errors)
+    const mapped = await composable(mapper)(res.data)
+    if (!mapped.success) return error(mapped.errors)
+    return mapped
+  }) as Composable<(...args: Parameters<T>) => R>
 }
 
 /**
@@ -201,12 +201,12 @@ function map<T extends Composable, R>(
  */
 function mapError<T extends Composable, R>(
   fn: T,
-  mapper: (err: Omit<Failure, "success">) => Omit<Failure, "success">,
+  mapper: (err: Omit<Failure, 'success'>) => Omit<Failure, 'success'>,
 ) {
   return (async (...args) => {
-    const res = await fn(...args);
-    return !res.success ? error(mapper(res).errors) : success(res.data);
-  }) as T;
+    const res = await fn(...args)
+    return !res.success ? error(mapper(res).errors) : success(res.data)
+  }) as T
 }
 
 export {
@@ -220,4 +220,5 @@ export {
   pipe,
   sequence,
   success,
-};
+}
+

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -1,13 +1,10 @@
-import { unknown } from 'https://deno.land/x/zod@v3.22.4/types.ts'
 import { toErrorWithMessage } from './errors.ts'
-import { Equal } from './types.test.ts'
 import {
   Composable,
   ErrorWithMessage,
   Failure,
   First,
   Fn,
-  Last,
   MergeObjs,
   Result,
   Success,
@@ -342,8 +339,6 @@ export {
   all,
   collect,
   composable,
-  composable as cf,
-  composable as λ,
   error,
   map,
   mapError,

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -71,7 +71,7 @@ function composable<T extends Fn>(fn: T): Composable<T> {
  * //    ^? Composable<({ aNumber }: { aNumber: number }) => { aBoolean: boolean }>
  */
 function pipe<T extends [Composable, ...Composable[]]>(
-  ...fns: T & PipeArguments<T, []>
+  ...fns: T & PipeArguments<T>
 ) {
   return (async (...args) => {
     //@ts-ignore pipe uses exactly he same generic input type as sequence
@@ -94,7 +94,7 @@ type PipeReturn<Fns extends any[]> = Fns extends [
   ? Composable<(...args: P) => O>
   : never
 
-type PipeArguments<Fns extends any[], Arguments extends any[]> = Fns extends [
+type PipeArguments<Fns extends any[], Arguments extends any[] = []> = Fns extends [
   Composable<(...a: infer PA) => infer OA>,
   Composable<(...b: infer PB) => infer OB>,
   ...infer rest,
@@ -135,7 +135,7 @@ type PipeArguments<Fns extends any[], Arguments extends any[]> = Fns extends [
 //       ^? Composable<(id: number) => [string, number, boolean]>
  */
 function all<T extends [Composable, ...Composable[]]>(
-  ...fns: T & AllArguments<T, []>
+  ...fns: T & AllArguments<T>
 ) {
   return (async (...args: any) => {
     const results = await Promise.all(fns.map((fn) => fn(...args)))
@@ -168,7 +168,7 @@ type SupertypesTuple<
   ? SupertypesTuple<[], restBNoA, [...O, headBNoA]>
   : O
 
-type AllArguments<Fns extends any[], Arguments extends any[]> = Fns extends [
+type AllArguments<Fns extends any[], Arguments extends any[] = []> = Fns extends [
   Composable<(...a: infer PA) => infer OA>,
   Composable<(...b: infer PB) => infer OB>,
   ...infer rest,
@@ -225,7 +225,7 @@ function collect<T extends Record<string, Composable>>(fns: T) {
  * //    ^? Composable<(aNumber: number) => [string, boolean]>
  */
 function sequence<T extends [Composable, ...Composable[]]>(
-  ...fns: T & PipeArguments<T, []>
+  ...fns: T & PipeArguments<T>
 ) {
   return (async (...args) => {
     const [head, ...tail] = fns as T

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -138,20 +138,20 @@ function all<T extends [Composable, ...Composable[]]>(
   >
 }
 
-type MatchAllArguments<
+type SupertypesTuple<
   TA extends unknown[],
   TB extends unknown[],
   O extends unknown[],
 > = TA extends [infer headA, ...infer restA]
   ? TB extends [infer headB, ...infer restB]
     ? headA extends headB
-      ? MatchAllArguments<restA, restB, [...O, headB]>
+      ? SupertypesTuple<restA, restB, [...O, headB]>
       : headB extends headA
-      ? MatchAllArguments<restA, restB, [...O, headA]>
+      ? SupertypesTuple<restA, restB, [...O, headA]>
       : { 'Incompatible arguments ': true; argument1: headA; argument2: headB }
-    : MatchAllArguments<restA, [], [...O, headA]>
+    : SupertypesTuple<restA, [], [...O, headA]>
   : TB extends [infer headBNoA, ...infer restBNoA]
-  ? MatchAllArguments<[], restBNoA, [...O, headBNoA]>
+  ? SupertypesTuple<[], restBNoA, [...O, headBNoA]>
   : O
 
 type AllArguments<Fns extends any[], Arguments extends any[]> = Fns extends [
@@ -159,7 +159,7 @@ type AllArguments<Fns extends any[], Arguments extends any[]> = Fns extends [
   Composable<(...b: infer PB) => infer OB>,
   ...infer rest,
 ]
-  ? MatchAllArguments<PA, PB, []> extends [...infer MergedP]
+  ? SupertypesTuple<PA, PB, []> extends [...infer MergedP]
     ? rest extends []
       ? [...Arguments, Composable<(...b: MergedP) => OB>]
       : AllArguments<

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -74,7 +74,7 @@ function pipe<T extends [Composable, ...Composable[]]>(
   ...fns: T & PipeArguments<T, []>
 ) {
   return (async (...args) => {
-    const res = await sequence(...(fns as T))(...(args as any))
+    const res = await (sequence(...(fns as any)) as any)(...(args as any))
     return !res.success ? error(res.errors) : success(res.data.at(-1))
   }) as PipeReturn<T>
 }
@@ -207,9 +207,11 @@ function collect<T extends Record<string, Composable>>(fns: T) {
  * const cf = C.sequence(a, b)
  * //    ^? Composable<(aNumber: number) => [string, boolean]>
  */
-function sequence<T extends [Composable, ...Composable[]]>(...fns: T) {
+function sequence<T extends [Composable, ...Composable[]]>(
+  ...fns: T & PipeArguments<T, []>
+) {
   return (async (...args) => {
-    const [head, ...tail] = fns
+    const [head, ...tail] = fns as T
 
     const res = await head(...args)
     if (!res.success) return error(res.errors)

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -7,6 +7,7 @@ import {
   Fn,
   Last,
   MergeObjs,
+  Result,
   Success,
   UnpackAll,
   UnpackResult,
@@ -77,6 +78,60 @@ function pipe<T extends [Composable, ...Composable[]]>(...fns: T) {
     ) => UnpackResult<ReturnType<Extract<Last<T>, Composable>>>
   >
 }
+
+function pt<Fns extends [Composable, ...Composable[]]>(
+  ...args: Fns & PipeArguments<Fns, []>
+): PipeReturn<Fns> {
+  return null as unknown as PipeReturn<Fns>
+}
+
+type PipeReturn<DFs extends any[]> = DFs extends [
+  Composable<(...a: infer PA) => infer OA>,
+  Composable<(b: infer PB) => infer OB>,
+  ...infer rest,
+]
+  ? PB extends OA
+    ? PipeReturn<[Composable<(...args: PA) => OB>, ...rest]>
+    : void
+  : DFs extends [Composable<(...args: infer P) => infer O>]
+  ? Composable<(...args: P) => O>
+  : void
+
+type PipeArguments<DFs extends any[], Arguments extends any[]> = DFs extends [
+  Composable<(...a: infer PA) => infer OA>,
+  Composable<(b: infer PB) => infer OB>,
+  ...infer rest,
+]
+  ? PB extends OA
+    ? PipeArguments<
+        [Composable<(...args: PA) => OB>, ...rest],
+        [...Arguments, Composable<(...a: PA) => OA>, Composable<(b: PB) => OB>]
+      >
+    : {parameterNext: PB, outputPrevious: OA}
+  : DFs extends [Composable<(...args: infer P) => infer O>, ...infer rest]
+  ? Arguments
+  : {dfs: DFs}
+
+// Awaited<T> extends Result<infer R> ? R : never
+
+type X = PipeArguments<
+  [Composable<() => string>, Composable<(a : string) => string>], []
+>
+
+const argA = composable(() => 'some string')
+const argB = composable((a: string) => 'a')
+const x = pt(
+  argA, argB
+)
+
+function tt<X extends (...args: any) => any>(id: X & ReturnType<X>) {}
+
+const s = composable(() => 'some string')
+const u = composable((s: string) => s.toUpperCase())
+const ok = pipe(s, u)
+const notOk = pipe(u, s)
+const ok2 = pt(s, u)
+const notOk2 = pt(u, s)
 
 /**
  * Creates a single function out of multiple Composables. It will pass the same input to each provided function. The functions will run in parallel. If all constituent functions are successful, The data field will be a tuple containing each function's output.
@@ -154,7 +209,6 @@ function sequence<T extends [Composable, ...Composable[]]>(...fns: T) {
     (...args: Parameters<Extract<First<T>, Composable>>) => UnpackAll<T>
   >
 }
-
 
 /**
  * It takes a Composable and a predicate to apply a transformation over the resulting `data`. It only runs if the function was successfull. When the given function fails, its error is returned wihout changes.

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -242,7 +242,7 @@ function collect<T extends Record<string, Composable>>(
     map(cf, (result) => ({ [key]: result })),
   )
   return map(all(...fnsWithKey as any), mergeObjects) as Composable<
-    (...args: Parameters<Extract<T[keyof T], Composable>>) => {
+    (...args: Parameters<AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>[0]>) => {
       [key in keyof T]: UnpackResult<ReturnType<Extract<T[key], Composable>>>
     }
   >

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -11,7 +11,6 @@ import {
   PipeArguments,
   PipeReturn,
   RecordToTuple,
-  Result,
   Success,
   UnpackAll,
   UnpackResult,
@@ -79,7 +78,7 @@ function pipe<T extends [Composable, ...Composable[]]>(
     //@ts-ignore pipe uses exactly he same generic input type as sequence
     //           I don't understand what is the issue here but ignoring the errors
     //           is safe and much nicer than a bunch of casts to any
-    const res = (await sequence(...fns)(...args)) as Result<unknown[]>
+    const res = (await sequence(...fns)(...args))
     return !res.success ? error(res.errors) : success(res.data.at(-1))
   }) as PipeReturn<T>
 }

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -146,26 +146,26 @@ function all<T extends [Composable, ...Composable[]]>(
 
     return success((results as Success<any>[]).map(({ data }) => data))
   }) as unknown as Composable<
-    (...args: Parameters<T[0]>) => {
+    (...args: Parameters<AllArguments<T>[0]>) => {
       [key in keyof T]: UnpackResult<ReturnType<Extract<T[key], Composable>>>
     }
   >
 }
 
-type SupertypesTuple<
+type SubtypesTuple<
   TA extends unknown[],
   TB extends unknown[],
   O extends unknown[],
 > = TA extends [infer headA, ...infer restA]
   ? TB extends [infer headB, ...infer restB]
     ? headA extends headB
-      ? SupertypesTuple<restA, restB, [...O, headB]>
+      ? SubtypesTuple<restA, restB, [...O, headA]>
       : headB extends headA
-      ? SupertypesTuple<restA, restB, [...O, headA]>
+      ? SubtypesTuple<restA, restB, [...O, headB]>
       : { 'Incompatible arguments ': true; argument1: headA; argument2: headB }
-    : SupertypesTuple<restA, [], [...O, headA]>
+    : SubtypesTuple<restA, [], [...O, headA]>
   : TB extends [infer headBNoA, ...infer restBNoA]
-  ? SupertypesTuple<[], restBNoA, [...O, headBNoA]>
+  ? SubtypesTuple<[], restBNoA, [...O, headBNoA]>
   : O
 
 type AllArguments<
@@ -173,7 +173,7 @@ type AllArguments<
   Arguments extends any[] = [],
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
   ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
-    ? SupertypesTuple<PA, PB, []> extends [...infer MergedP]
+    ? SubtypesTuple<PA, PB, []> extends [...infer MergedP]
       ? AllArguments<
           [Composable<(...args: MergedP) => OB>, ...restB],
           [...Arguments, Composable<(...a: MergedP) => OA>]

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -74,7 +74,10 @@ function pipe<T extends [Composable, ...Composable[]]>(
   ...fns: T & PipeArguments<T, []>
 ) {
   return (async (...args) => {
-    const res = await (sequence(...(fns as any)) as any)(...(args as any))
+    //@ts-ignore pipe uses exactly he same generic input type as sequence
+    //           I don't understand what is the issue here but ignoring the errors
+    //           is safe and much nicer than a bunch of casts to any
+    const res = await sequence(...fns)(...args)
     return !res.success ? error(res.errors) : success(res.data.at(-1))
   }) as PipeReturn<T>
 }

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -164,7 +164,10 @@ describe('collect', () => {
       Equal<
         typeof fn,
         Composable<
-          (...args: [] | [a: number, b: number] | [a: unknown]) => {
+          (
+            a: number,
+            b: number,
+          ) => {
             add: number
             string: string
             void: void
@@ -190,20 +193,21 @@ describe('collect', () => {
       add: add,
       string: append,
     })
+    //@ts-expect-error add and append parameters are incompatible
     const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<
         typeof fn,
         Composable<
-          (...args: [a: number, b: number] | [a: string, b: string]) => {
+          (...args: never) => {
             add: number
             string: string
           }
         >
       >
     >
-    type _R = Expect<Equal<typeof res, Result<{ add: number; string: string }>>>
+    type _R = Expect<Equal<typeof res, Result<any>>>
     assertEquals(res, {
       success: true,
       data: { add: 3, string: '12' },

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -5,17 +5,17 @@ import { Equal, Expect } from './types.test.ts'
 import { all, collect, λ } from './composable.ts'
 
 const voidFn = () => {}
-const toString = (a: unknown) => `${a}`
+const toString = λ((a: unknown) => `${a}`)
 const append = (a: string, b: string) => `${a}${b}`
-const add = (a: number, b: number) => a + b
+const add = λ((a: number, b: number) => a + b)
 const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
-const faultyAdd = (a: number, b: number) => {
+const faultyAdd = λ((a: number, b: number) => {
   if (a === 1) throw new Error('a is 1')
   return a + b
-}
-const alwaysThrow = () => {
+})
+const alwaysThrow = λ(() => {
   throw new Error('always throw', { cause: 'it was made for this' })
-}
+})
 
 describe('composable', () => {
   it('infers the types if has no arguments or return', async () => {
@@ -29,7 +29,7 @@ describe('composable', () => {
   })
 
   it('infers the types if has arguments and a return', async () => {
-    const fn = λ(add)
+    const fn = add
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -53,7 +53,7 @@ describe('composable', () => {
   })
 
   it('catch errors', async () => {
-    const fn = λ(faultyAdd)
+    const fn = faultyAdd
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -68,7 +68,7 @@ describe('composable', () => {
 
 describe('pipe', () => {
   it('sends the results of the first function to the second and infers types', async () => {
-    const fn = pipe(λ(add), λ(toString))
+    const fn = pipe(add, toString)
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -80,7 +80,7 @@ describe('pipe', () => {
   })
 
   it('catches the errors from function A', async () => {
-    const fn = pipe(λ(faultyAdd), λ(toString))
+    const fn = pipe(faultyAdd, toString)
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -93,7 +93,8 @@ describe('pipe', () => {
   })
 
   it('catches the errors from function B', async () => {
-    const fn = pipe(λ(add), λ(alwaysThrow), λ(toString))
+    //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
+    const fn = pipe(add, alwaysThrow, toString)
     // TODO this should not type check
     const res = await fn(1, 2)
 
@@ -115,7 +116,7 @@ describe('pipe', () => {
 
 describe('sequence', () => {
   it('sends the results of the first function to the second and saves every step of the result', async () => {
-    const fn = sequence(λ(add), λ(toString))
+    const fn = sequence(add, toString)
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -127,7 +128,7 @@ describe('sequence', () => {
   })
 
   it('catches the errors from function A', async () => {
-    const fn = sequence(λ(faultyAdd), λ(toString))
+    const fn = sequence(faultyAdd, toString)
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -142,7 +143,7 @@ describe('sequence', () => {
 
 describe('all', () => {
   it('executes all functions using the same input returning a tuple with every result when all are successful', async () => {
-    const fn = all(λ(add), λ(toString), λ(voidFn))
+    const fn = all(add, toString, λ(voidFn))
 
     const res = await fn(1, 2)
 
@@ -153,8 +154,8 @@ describe('all', () => {
 describe('collect', () => {
   it('collects the results of an object of Composables into a result with same format', async () => {
     const fn = collect({
-      add: λ(add),
-      string: λ(toString),
+      add: add,
+      string: toString,
       void: λ(voidFn),
     })
     const res = await fn(1, 2)
@@ -184,7 +185,7 @@ describe('collect', () => {
 
   it('uses the same arguments for every function', async () => {
     const fn = collect({
-      add: λ(add),
+      add: add,
       string: λ(append),
     })
     const res = await fn(1, 2)
@@ -210,8 +211,8 @@ describe('collect', () => {
 
   it('collects the errors in the error array', async () => {
     const fn = collect({
-      error1: λ(faultyAdd),
-      error2: λ(faultyAdd),
+      error1: faultyAdd,
+      error2: faultyAdd,
     })
     const res = await fn(1, 2)
 
@@ -241,7 +242,7 @@ describe('collect', () => {
 
 describe('map', () => {
   it('maps over an Composable function successful result', async () => {
-    const fn = map(λ(add), (a) => a + 1 === 4)
+    const fn = map(add, (a) => a + 1 === 4)
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -253,7 +254,7 @@ describe('map', () => {
   })
 
   it('maps over a composition', async () => {
-    const fn = map(pipe(λ(add), λ(toString)), (a) => typeof a === 'string')
+    const fn = map(pipe(add, toString), (a) => typeof a === 'string')
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -265,7 +266,7 @@ describe('map', () => {
   })
 
   it('does not do anything when the function fails', async () => {
-    const fn = map(λ(faultyAdd), (a) => a + 1 === 4)
+    const fn = map(faultyAdd, (a) => a + 1 === 4)
     const res = await fn(1, 2)
 
     type _FN = Expect<
@@ -283,7 +284,7 @@ const cleanError = (err: ErrorWithMessage) => ({
 })
 describe('mapError', () => {
   it('maps over the error results of an Composable function', async () => {
-    const fn = mapError(λ(faultyAdd), ({ errors }) => ({
+    const fn = mapError(faultyAdd, ({ errors }) => ({
       errors: errors.map(cleanError),
     }))
     const res = await fn(1, 2)

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -1,164 +1,164 @@
-import { assertEquals, describe, it } from "../test-prelude.ts";
-import { map, mapError, pipe, sequence } from "./index.ts";
-import type { Composable, ErrorWithMessage, Result } from "./index.ts";
-import { Equal, Expect } from "./types.test.ts";
-import { all, collect, composable } from "./composable.ts";
+import { assertEquals, describe, it } from '../test-prelude.ts'
+import { map, mapError, pipe, sequence } from './index.ts'
+import type { Composable, ErrorWithMessage, Result } from './index.ts'
+import { Equal, Expect } from './types.test.ts'
+import { all, collect, composable } from './composable.ts'
 
-const voidFn = composable(() => {});
-const toString = composable((a: unknown) => `${a}`);
-const append = composable((a: string, b: string) => `${a}${b}`);
-const add = composable((a: number, b: number) => a + b);
-const asyncAdd = (a: number, b: number) => Promise.resolve(a + b);
+const voidFn = composable(() => {})
+const toString = composable((a: unknown) => `${a}`)
+const append = composable((a: string, b: string) => `${a}${b}`)
+const add = composable((a: number, b: number) => a + b)
+const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
 const faultyAdd = composable((a: number, b: number) => {
-  if (a === 1) throw new Error("a is 1");
-  return a + b;
-});
+  if (a === 1) throw new Error('a is 1')
+  return a + b
+})
 const alwaysThrow = composable(() => {
-  throw new Error("always throw", { cause: "it was made for this" });
-});
+  throw new Error('always throw', { cause: 'it was made for this' })
+})
 
-describe("composable", () => {
-  it("infers the types if has no arguments or return", async () => {
-    const fn = composable(() => {});
-    const res = await fn();
+describe('composable', () => {
+  it('infers the types if has no arguments or return', async () => {
+    const fn = composable(() => {})
+    const res = await fn()
 
-    type _FN = Expect<Equal<typeof fn, Composable<() => void>>>;
-    type _R = Expect<Equal<typeof res, Result<void>>>;
+    type _FN = Expect<Equal<typeof fn, Composable<() => void>>>
+    type _R = Expect<Equal<typeof res, Result<void>>>
 
-    assertEquals(res, { success: true, data: undefined, errors: [] });
-  });
+    assertEquals(res, { success: true, data: undefined, errors: [] })
+  })
 
-  it("infers the types if has arguments and a return", async () => {
-    const fn = add;
-    const res = await fn(1, 2);
-
-    type _FN = Expect<
-      Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<number>>>;
-
-    assertEquals(res, { success: true, data: 3, errors: [] });
-  });
-
-  it("infers the types of async functions", async () => {
-    const fn = composable(asyncAdd);
-    const res = await fn(1, 2);
+  it('infers the types if has arguments and a return', async () => {
+    const fn = add
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<number>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<number>>>
 
-    assertEquals(res, { success: true, data: 3, errors: [] });
-  });
+    assertEquals(res, { success: true, data: 3, errors: [] })
+  })
 
-  it("catch errors", async () => {
-    const fn = faultyAdd;
-    const res = await fn(1, 2);
+  it('infers the types of async functions', async () => {
+    const fn = composable(asyncAdd)
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<number>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<number>>>
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "a is 1");
-  });
-});
+    assertEquals(res, { success: true, data: 3, errors: [] })
+  })
 
-describe("pipe", () => {
-  it("sends the results of the first function to the second and infers types", async () => {
-    const fn = pipe(add, toString);
-    const res = await fn(1, 2);
+  it('catch errors', async () => {
+    const fn = faultyAdd
+    const res = await fn(1, 2)
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => number>>
+    >
+    type _R = Expect<Equal<typeof res, Result<number>>>
+
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'a is 1')
+  })
+})
+
+describe('pipe', () => {
+  it('sends the results of the first function to the second and infers types', async () => {
+    const fn = pipe(add, toString)
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<string>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<string>>>
 
-    assertEquals(res, { success: true, data: "3", errors: [] });
-  });
+    assertEquals(res, { success: true, data: '3', errors: [] })
+  })
 
-  it("catches the errors from function A", async () => {
-    const fn = pipe(faultyAdd, toString);
-    const res = await fn(1, 2);
+  it('catches the errors from function A', async () => {
+    const fn = pipe(faultyAdd, toString)
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<string>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<string>>>
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "a is 1");
-  });
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'a is 1')
+  })
 
-  it("catches the errors from function B", async () => {
+  it('catches the errors from function B', async () => {
     //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
-    const fn = pipe(add, alwaysThrow, toString);
+    const fn = pipe(add, alwaysThrow, toString)
     //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
-    const res = await fn(1, 2);
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<string>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<string>>>
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "always throw");
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'always throw')
     assertEquals(
       // deno-lint-ignore no-explicit-any
       (res.errors[0] as any).exception?.cause,
-      "it was made for this",
-    );
-  });
-});
+      'it was made for this',
+    )
+  })
+})
 
-describe("sequence", () => {
-  it("sends the results of the first function to the second and saves every step of the result", async () => {
-    const fn = sequence(add, toString);
-    const res = await fn(1, 2);
-
-    type _FN = Expect<
-      Equal<typeof fn, Composable<(a: number, b: number) => [number, string]>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<[number, string]>>>;
-
-    assertEquals(res, { success: true, data: [3, "3"], errors: [] });
-  });
-
-  it("catches the errors from function A", async () => {
-    const fn = sequence(faultyAdd, toString);
-    const res = await fn(1, 2);
+describe('sequence', () => {
+  it('sends the results of the first function to the second and saves every step of the result', async () => {
+    const fn = sequence(add, toString)
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => [number, string]>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<[number, string]>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<[number, string]>>>
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "a is 1");
-  });
-});
+    assertEquals(res, { success: true, data: [3, '3'], errors: [] })
+  })
 
-describe("all", () => {
-  it("executes all functions using the same input returning a tuple with every result when all are successful", async () => {
-    const fn = all(add, toString, voidFn);
+  it('catches the errors from function A', async () => {
+    const fn = sequence(faultyAdd, toString)
+    const res = await fn(1, 2)
 
-    const res = await fn(1, 2);
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => [number, string]>>
+    >
+    type _R = Expect<Equal<typeof res, Result<[number, string]>>>
 
-    assertEquals(res, { success: true, data: [3, "1", undefined], errors: [] });
-  });
-});
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'a is 1')
+  })
+})
 
-describe("collect", () => {
-  it("collects the results of an object of Composables into a result with same format", async () => {
+describe('all', () => {
+  it('executes all functions using the same input returning a tuple with every result when all are successful', async () => {
+    const fn = all(add, toString, voidFn)
+
+    const res = await fn(1, 2)
+
+    assertEquals(res, { success: true, data: [3, '1', undefined], errors: [] })
+  })
+})
+
+describe('collect', () => {
+  it('collects the results of an object of Composables into a result with same format', async () => {
     const fn = collect({
       add: add,
       string: toString,
       void: voidFn,
-    });
-    const res = await fn(1, 2);
+    })
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<
@@ -168,59 +168,59 @@ describe("collect", () => {
             a: number,
             b: number,
           ) => {
-            add: number;
-            string: string;
-            void: void;
+            add: number
+            string: string
+            void: void
           }
         >
       >
-    >;
+    >
     type _R = Expect<
       Equal<typeof res, Result<{ add: number; string: string; void: void }>>
-    >;
+    >
 
     assertEquals(res, {
       success: true,
-      data: { add: 3, string: "1", void: undefined },
+      data: { add: 3, string: '1', void: undefined },
       errors: [],
-    });
-  });
+    })
+  })
 
-  it("uses the same arguments for every function", async () => {
+  it('uses the same arguments for every function', async () => {
     //@ts-expect-error add and append parameters are incompatible
     // The runtime will work since passing 1, 2 will be coerced to '1', '2'
     const fn = collect({
       add: add,
       string: append,
-    });
+    })
     //@ts-expect-error add and append parameters are incompatible
-    const res = await fn(1, 2);
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<
         typeof fn,
         Composable<
           (...args: never) => {
-            add: number;
-            string: string;
+            add: number
+            string: string
           }
         >
       >
-    >;
-    type _R = Expect<Equal<typeof res, Result<any>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<any>>>
     assertEquals(res, {
       success: true,
-      data: { add: 3, string: "12" },
+      data: { add: 3, string: '12' },
       errors: [],
-    });
-  });
+    })
+  })
 
-  it("collects the errors in the error array", async () => {
+  it('collects the errors in the error array', async () => {
     const fn = collect({
       error1: faultyAdd,
       error2: faultyAdd,
-    });
-    const res = await fn(1, 2);
+    })
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<
@@ -230,77 +230,78 @@ describe("collect", () => {
             a: number,
             b: number,
           ) => {
-            error1: number;
-            error2: number;
+            error1: number
+            error2: number
           }
         >
       >
-    >;
+    >
     type _R = Expect<
       Equal<typeof res, Result<{ error1: number; error2: number }>>
-    >;
+    >
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "a is 1");
-    assertEquals(res.errors![1].message, "a is 1");
-  });
-});
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'a is 1')
+    assertEquals(res.errors![1].message, 'a is 1')
+  })
+})
 
-describe("map", () => {
-  it("maps over an Composable function successful result", async () => {
-    const fn = map(add, (a) => a + 1 === 4);
-    const res = await fn(1, 2);
-
-    type _FN = Expect<
-      Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<boolean>>>;
-
-    assertEquals(res, { success: true, data: true, errors: [] });
-  });
-
-  it("maps over a composition", async () => {
-    const fn = map(pipe(add, toString), (a) => typeof a === "string");
-    const res = await fn(1, 2);
+describe('map', () => {
+  it('maps over an Composable function successful result', async () => {
+    const fn = map(add, (a) => a + 1 === 4)
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<boolean>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<boolean>>>
 
-    assertEquals(res, { success: true, data: true, errors: [] });
-  });
+    assertEquals(res, { success: true, data: true, errors: [] })
+  })
 
-  it("does not do anything when the function fails", async () => {
-    const fn = map(faultyAdd, (a) => a + 1 === 4);
-    const res = await fn(1, 2);
+  it('maps over a composition', async () => {
+    const fn = map(pipe(add, toString), (a) => typeof a === 'string')
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<boolean>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<boolean>>>
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "a is 1");
-  });
-});
+    assertEquals(res, { success: true, data: true, errors: [] })
+  })
+
+  it('does not do anything when the function fails', async () => {
+    const fn = map(faultyAdd, (a) => a + 1 === 4)
+    const res = await fn(1, 2)
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
+    >
+    type _R = Expect<Equal<typeof res, Result<boolean>>>
+
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'a is 1')
+  })
+})
 
 const cleanError = (err: ErrorWithMessage) => ({
-  message: err.message + "!!!",
-});
-describe("mapError", () => {
-  it("maps over the error results of an Composable function", async () => {
+  message: err.message + '!!!',
+})
+describe('mapError', () => {
+  it('maps over the error results of an Composable function', async () => {
     const fn = mapError(faultyAdd, ({ errors }) => ({
       errors: errors.map(cleanError),
-    }));
-    const res = await fn(1, 2);
+    }))
+    const res = await fn(1, 2)
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >;
-    type _R = Expect<Equal<typeof res, Result<number>>>;
+    >
+    type _R = Expect<Equal<typeof res, Result<number>>>
 
-    assertEquals(res.success, false);
-    assertEquals(res.errors![0].message, "a is 1!!!");
-  });
-});
+    assertEquals(res.success, false)
+    assertEquals(res.errors![0].message, 'a is 1!!!')
+  })
+})
+

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -1,164 +1,164 @@
-import { assertEquals, describe, it } from '../test-prelude.ts'
-import { map, mapError, pipe, sequence } from './index.ts'
-import type { Composable, ErrorWithMessage, Result } from './index.ts'
-import { Equal, Expect } from './types.test.ts'
-import { all, collect, composable } from './composable.ts'
+import { assertEquals, describe, it } from "../test-prelude.ts";
+import { map, mapError, pipe, sequence } from "./index.ts";
+import type { Composable, ErrorWithMessage, Result } from "./index.ts";
+import { Equal, Expect } from "./types.test.ts";
+import { all, collect, composable } from "./composable.ts";
 
-const voidFn = composable(() => {})
-const toString = composable((a: unknown) => `${a}`)
-const append = composable((a: string, b: string) => `${a}${b}`)
-const add = composable((a: number, b: number) => a + b)
-const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
+const voidFn = composable(() => {});
+const toString = composable((a: unknown) => `${a}`);
+const append = composable((a: string, b: string) => `${a}${b}`);
+const add = composable((a: number, b: number) => a + b);
+const asyncAdd = (a: number, b: number) => Promise.resolve(a + b);
 const faultyAdd = composable((a: number, b: number) => {
-  if (a === 1) throw new Error('a is 1')
-  return a + b
-})
+  if (a === 1) throw new Error("a is 1");
+  return a + b;
+});
 const alwaysThrow = composable(() => {
-  throw new Error('always throw', { cause: 'it was made for this' })
-})
+  throw new Error("always throw", { cause: "it was made for this" });
+});
 
-describe('composable', () => {
-  it('infers the types if has no arguments or return', async () => {
-    const fn = composable(() => {})
-    const res = await fn()
+describe("composable", () => {
+  it("infers the types if has no arguments or return", async () => {
+    const fn = composable(() => {});
+    const res = await fn();
 
-    type _FN = Expect<Equal<typeof fn, Composable<() => void>>>
-    type _R = Expect<Equal<typeof res, Result<void>>>
+    type _FN = Expect<Equal<typeof fn, Composable<() => void>>>;
+    type _R = Expect<Equal<typeof res, Result<void>>>;
 
-    assertEquals(res, { success: true, data: undefined, errors: [] })
-  })
+    assertEquals(res, { success: true, data: undefined, errors: [] });
+  });
 
-  it('infers the types if has arguments and a return', async () => {
-    const fn = add
-    const res = await fn(1, 2)
-
-    type _FN = Expect<
-      Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >
-    type _R = Expect<Equal<typeof res, Result<number>>>
-
-    assertEquals(res, { success: true, data: 3, errors: [] })
-  })
-
-  it('infers the types of async functions', async () => {
-    const fn = composable(asyncAdd)
-    const res = await fn(1, 2)
+  it("infers the types if has arguments and a return", async () => {
+    const fn = add;
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >
-    type _R = Expect<Equal<typeof res, Result<number>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<number>>>;
 
-    assertEquals(res, { success: true, data: 3, errors: [] })
-  })
+    assertEquals(res, { success: true, data: 3, errors: [] });
+  });
 
-  it('catch errors', async () => {
-    const fn = faultyAdd
-    const res = await fn(1, 2)
+  it("infers the types of async functions", async () => {
+    const fn = composable(asyncAdd);
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >
-    type _R = Expect<Equal<typeof res, Result<number>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<number>>>;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
-  })
-})
+    assertEquals(res, { success: true, data: 3, errors: [] });
+  });
 
-describe('pipe', () => {
-  it('sends the results of the first function to the second and infers types', async () => {
-    const fn = pipe(add, toString)
-    const res = await fn(1, 2)
+  it("catch errors", async () => {
+    const fn = faultyAdd;
+    const res = await fn(1, 2);
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => number>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<number>>>;
+
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "a is 1");
+  });
+});
+
+describe("pipe", () => {
+  it("sends the results of the first function to the second and infers types", async () => {
+    const fn = pipe(add, toString);
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
-    >
-    type _R = Expect<Equal<typeof res, Result<string>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<string>>>;
 
-    assertEquals(res, { success: true, data: '3', errors: [] })
-  })
+    assertEquals(res, { success: true, data: "3", errors: [] });
+  });
 
-  it('catches the errors from function A', async () => {
-    const fn = pipe(faultyAdd, toString)
-    const res = await fn(1, 2)
+  it("catches the errors from function A", async () => {
+    const fn = pipe(faultyAdd, toString);
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
-    >
-    type _R = Expect<Equal<typeof res, Result<string>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<string>>>;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
-  })
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "a is 1");
+  });
 
-  it('catches the errors from function B', async () => {
+  it("catches the errors from function B", async () => {
     //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
-    const fn = pipe(add, alwaysThrow, toString)
+    const fn = pipe(add, alwaysThrow, toString);
     //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
-    const res = await fn(1, 2)
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
-    >
-    type _R = Expect<Equal<typeof res, Result<string>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<string>>>;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'always throw')
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "always throw");
     assertEquals(
       // deno-lint-ignore no-explicit-any
       (res.errors[0] as any).exception?.cause,
-      'it was made for this',
-    )
-  })
-})
+      "it was made for this",
+    );
+  });
+});
 
-describe('sequence', () => {
-  it('sends the results of the first function to the second and saves every step of the result', async () => {
-    const fn = sequence(add, toString)
-    const res = await fn(1, 2)
-
-    type _FN = Expect<
-      Equal<typeof fn, Composable<(a: number, b: number) => [number, string]>>
-    >
-    type _R = Expect<Equal<typeof res, Result<[number, string]>>>
-
-    assertEquals(res, { success: true, data: [3, '3'], errors: [] })
-  })
-
-  it('catches the errors from function A', async () => {
-    const fn = sequence(faultyAdd, toString)
-    const res = await fn(1, 2)
+describe("sequence", () => {
+  it("sends the results of the first function to the second and saves every step of the result", async () => {
+    const fn = sequence(add, toString);
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => [number, string]>>
-    >
-    type _R = Expect<Equal<typeof res, Result<[number, string]>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<[number, string]>>>;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
-  })
-})
+    assertEquals(res, { success: true, data: [3, "3"], errors: [] });
+  });
 
-describe('all', () => {
-  it('executes all functions using the same input returning a tuple with every result when all are successful', async () => {
-    const fn = all(add, toString, voidFn)
+  it("catches the errors from function A", async () => {
+    const fn = sequence(faultyAdd, toString);
+    const res = await fn(1, 2);
 
-    const res = await fn(1, 2)
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => [number, string]>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<[number, string]>>>;
 
-    assertEquals(res, { success: true, data: [3, '1', undefined], errors: [] })
-  })
-})
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "a is 1");
+  });
+});
 
-describe('collect', () => {
-  it('collects the results of an object of Composables into a result with same format', async () => {
+describe("all", () => {
+  it("executes all functions using the same input returning a tuple with every result when all are successful", async () => {
+    const fn = all(add, toString, voidFn);
+
+    const res = await fn(1, 2);
+
+    assertEquals(res, { success: true, data: [3, "1", undefined], errors: [] });
+  });
+});
+
+describe("collect", () => {
+  it("collects the results of an object of Composables into a result with same format", async () => {
     const fn = collect({
       add: add,
       string: toString,
       void: voidFn,
-    })
-    const res = await fn(1, 2)
+    });
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<
@@ -168,59 +168,59 @@ describe('collect', () => {
             a: number,
             b: number,
           ) => {
-            add: number
-            string: string
-            void: void
+            add: number;
+            string: string;
+            void: void;
           }
         >
       >
-    >
+    >;
     type _R = Expect<
       Equal<typeof res, Result<{ add: number; string: string; void: void }>>
-    >
+    >;
 
     assertEquals(res, {
       success: true,
-      data: { add: 3, string: '1', void: undefined },
+      data: { add: 3, string: "1", void: undefined },
       errors: [],
-    })
-  })
+    });
+  });
 
-  it('uses the same arguments for every function', async () => {
+  it("uses the same arguments for every function", async () => {
     //@ts-expect-error add and append parameters are incompatible
     // The runtime will work since passing 1, 2 will be coerced to '1', '2'
     const fn = collect({
       add: add,
       string: append,
-    })
+    });
     //@ts-expect-error add and append parameters are incompatible
-    const res = await fn(1, 2)
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<
         typeof fn,
         Composable<
           (...args: never) => {
-            add: number
-            string: string
+            add: number;
+            string: string;
           }
         >
       >
-    >
-    type _R = Expect<Equal<typeof res, Result<any>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<any>>>;
     assertEquals(res, {
       success: true,
-      data: { add: 3, string: '12' },
+      data: { add: 3, string: "12" },
       errors: [],
-    })
-  })
+    });
+  });
 
-  it('collects the errors in the error array', async () => {
+  it("collects the errors in the error array", async () => {
     const fn = collect({
       error1: faultyAdd,
       error2: faultyAdd,
-    })
-    const res = await fn(1, 2)
+    });
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<
@@ -230,78 +230,77 @@ describe('collect', () => {
             a: number,
             b: number,
           ) => {
-            error1: number
-            error2: number
+            error1: number;
+            error2: number;
           }
         >
       >
-    >
+    >;
     type _R = Expect<
       Equal<typeof res, Result<{ error1: number; error2: number }>>
-    >
+    >;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
-    assertEquals(res.errors![1].message, 'a is 1')
-  })
-})
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "a is 1");
+    assertEquals(res.errors![1].message, "a is 1");
+  });
+});
 
-describe('map', () => {
-  it('maps over an Composable function successful result', async () => {
-    const fn = map(add, (a) => a + 1 === 4)
-    const res = await fn(1, 2)
-
-    type _FN = Expect<
-      Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
-    >
-    type _R = Expect<Equal<typeof res, Result<boolean>>>
-
-    assertEquals(res, { success: true, data: true, errors: [] })
-  })
-
-  it('maps over a composition', async () => {
-    const fn = map(pipe(add, toString), (a) => typeof a === 'string')
-    const res = await fn(1, 2)
+describe("map", () => {
+  it("maps over an Composable function successful result", async () => {
+    const fn = map(add, (a) => a + 1 === 4);
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
-    >
-    type _R = Expect<Equal<typeof res, Result<boolean>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<boolean>>>;
 
-    assertEquals(res, { success: true, data: true, errors: [] })
-  })
+    assertEquals(res, { success: true, data: true, errors: [] });
+  });
 
-  it('does not do anything when the function fails', async () => {
-    const fn = map(faultyAdd, (a) => a + 1 === 4)
-    const res = await fn(1, 2)
+  it("maps over a composition", async () => {
+    const fn = map(pipe(add, toString), (a) => typeof a === "string");
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
-    >
-    type _R = Expect<Equal<typeof res, Result<boolean>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<boolean>>>;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1')
-  })
-})
+    assertEquals(res, { success: true, data: true, errors: [] });
+  });
+
+  it("does not do anything when the function fails", async () => {
+    const fn = map(faultyAdd, (a) => a + 1 === 4);
+    const res = await fn(1, 2);
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => boolean>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<boolean>>>;
+
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "a is 1");
+  });
+});
 
 const cleanError = (err: ErrorWithMessage) => ({
-  message: err.message + '!!!',
-})
-describe('mapError', () => {
-  it('maps over the error results of an Composable function', async () => {
+  message: err.message + "!!!",
+});
+describe("mapError", () => {
+  it("maps over the error results of an Composable function", async () => {
     const fn = mapError(faultyAdd, ({ errors }) => ({
       errors: errors.map(cleanError),
-    }))
-    const res = await fn(1, 2)
+    }));
+    const res = await fn(1, 2);
 
     type _FN = Expect<
       Equal<typeof fn, Composable<(a: number, b: number) => number>>
-    >
-    type _R = Expect<Equal<typeof res, Result<number>>>
+    >;
+    type _R = Expect<Equal<typeof res, Result<number>>>;
 
-    assertEquals(res.success, false)
-    assertEquals(res.errors![0].message, 'a is 1!!!')
-  })
-})
-
+    assertEquals(res.success, false);
+    assertEquals(res.errors![0].message, "a is 1!!!");
+  });
+});

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -95,11 +95,11 @@ describe('pipe', () => {
   it('catches the errors from function B', async () => {
     //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
     const fn = pipe(add, alwaysThrow, toString)
-    // TODO this should not type check
+    //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
     const res = await fn(1, 2)
 
-    // TODO this should be a type error
     type _FN = Expect<
+      //@ts-expect-error alwaysThrow won't type-check the composition since its return type is never and toString expects an unknown parameter
       Equal<typeof fn, Composable<(a: number, b: number) => string>>
     >
     type _R = Expect<Equal<typeof res, Result<string>>>

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -6,7 +6,7 @@ import { all, collect, λ } from './composable.ts'
 
 const voidFn = λ(() => {})
 const toString = λ((a: unknown) => `${a}`)
-const append = (a: string, b: string) => `${a}${b}`
+const append = λ((a: string, b: string) => `${a}${b}`)
 const add = λ((a: number, b: number) => a + b)
 const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
 const faultyAdd = λ((a: number, b: number) => {
@@ -184,9 +184,11 @@ describe('collect', () => {
   })
 
   it('uses the same arguments for every function', async () => {
+    //@ts-expect-error add and append parameters are incompatible
+    // The runtime will work since passing 1, 2 will be coerced to '1', '2'
     const fn = collect({
       add: add,
-      string: λ(append),
+      string: append,
     })
     const res = await fn(1, 2)
 

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -4,7 +4,7 @@ import type { Composable, ErrorWithMessage, Result } from './index.ts'
 import { Equal, Expect } from './types.test.ts'
 import { all, collect, λ } from './composable.ts'
 
-const voidFn = () => {}
+const voidFn = λ(() => {})
 const toString = λ((a: unknown) => `${a}`)
 const append = (a: string, b: string) => `${a}${b}`
 const add = λ((a: number, b: number) => a + b)
@@ -143,7 +143,7 @@ describe('sequence', () => {
 
 describe('all', () => {
   it('executes all functions using the same input returning a tuple with every result when all are successful', async () => {
-    const fn = all(add, toString, λ(voidFn))
+    const fn = all(add, toString, voidFn)
 
     const res = await fn(1, 2)
 
@@ -156,7 +156,7 @@ describe('collect', () => {
     const fn = collect({
       add: add,
       string: toString,
-      void: λ(voidFn),
+      void: voidFn,
     })
     const res = await fn(1, 2)
 

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -2,24 +2,24 @@ import { assertEquals, describe, it } from '../test-prelude.ts'
 import { map, mapError, pipe, sequence } from './index.ts'
 import type { Composable, ErrorWithMessage, Result } from './index.ts'
 import { Equal, Expect } from './types.test.ts'
-import { all, collect, λ } from './composable.ts'
+import { all, collect, composable } from './composable.ts'
 
-const voidFn = λ(() => {})
-const toString = λ((a: unknown) => `${a}`)
-const append = λ((a: string, b: string) => `${a}${b}`)
-const add = λ((a: number, b: number) => a + b)
+const voidFn = composable(() => {})
+const toString = composable((a: unknown) => `${a}`)
+const append = composable((a: string, b: string) => `${a}${b}`)
+const add = composable((a: number, b: number) => a + b)
 const asyncAdd = (a: number, b: number) => Promise.resolve(a + b)
-const faultyAdd = λ((a: number, b: number) => {
+const faultyAdd = composable((a: number, b: number) => {
   if (a === 1) throw new Error('a is 1')
   return a + b
 })
-const alwaysThrow = λ(() => {
+const alwaysThrow = composable(() => {
   throw new Error('always throw', { cause: 'it was made for this' })
 })
 
 describe('composable', () => {
   it('infers the types if has no arguments or return', async () => {
-    const fn = λ(() => {})
+    const fn = composable(() => {})
     const res = await fn()
 
     type _FN = Expect<Equal<typeof fn, Composable<() => void>>>
@@ -41,7 +41,7 @@ describe('composable', () => {
   })
 
   it('infers the types of async functions', async () => {
-    const fn = λ(asyncAdd)
+    const fn = composable(asyncAdd)
     const res = await fn(1, 2)
 
     type _FN = Expect<

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -1,17 +1,12 @@
 // deno-lint-ignore-file ban-ts-comment no-namespace no-unused-vars
-import {
-  assertEquals,
-  describe,
-  it,
-} from '../test-prelude.ts'
+import { assertEquals, describe, it } from '../test-prelude.ts'
 import * as Subject from './types.ts'
 
 export type Expect<T extends true> = T
 export type Equal<A, B> =
   // prettier is removing the parens thus worsening readability
   // prettier-ignore
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
-    ? true
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true
     : false
 
 namespace MergeObjs {
@@ -65,5 +60,41 @@ namespace AtLeastOne {
   const error2: Result = { a: 1, c: 3 }
 }
 
+namespace AllArguments {
+  type testNoEmptyArgumentList = Expect<Equal<Subject.AllArguments<[]>, never>>
+  type testOneComposable = Expect<
+    Equal<Subject.AllArguments<[Subject.Composable]>, [Subject.Composable]>
+  >
+  type testSubtypesForTwoComposables = Expect<
+    Equal<
+      Subject.AllArguments<
+        [
+          Subject.Composable<(x: string, y: 1) => void>,
+          Subject.Composable<(x: 'foo', y: number) => void>,
+        ]
+      >,
+      [
+        Subject.Composable<(x: 'foo', y: 1) => void>,
+        Subject.Composable<(x: 'foo', y: 1) => void>,
+      ]
+    >
+  >
+  type testMaxArityForTwoComposables = Expect<
+    Equal<
+      Subject.AllArguments<
+        [
+          Subject.Composable<(x: string, y: number) => void>,
+          Subject.Composable<(x: 'foo') => void>,
+        ]
+      >,
+      [
+        Subject.Composable<(x: 'foo', y: number) => void>,
+        Subject.Composable<(x: 'foo', y: number) => void>,
+      ]
+    >
+  >
+}
+
 describe('type tests', () =>
   it('should have no ts errors', () => assertEquals(true, true)))
+

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -7,7 +7,7 @@ export type Equal<A, B> =
   // prettier is removing the parens thus worsening readability
   // prettier-ignore
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true
-    : false
+    : [A, 'should equal', B]
 
 namespace MergeObjs {
   const obj1 = { a: 1, b: 2 } as const

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -152,6 +152,49 @@ namespace AllArguments {
   >
 }
 
+type x = Subject.CollectArguments<{
+  a: Subject.Composable<(x: string, y: 1) => void>
+  b: Subject.Composable<(x: 'foo', y: number) => void>
+}>
+
+namespace CollectArguments {
+  type testNoEmptyArgumentList = Expect<
+    Equal<Subject.CollectArguments<{}>, never>
+  >
+  type testOneComposable = Expect<
+    Equal<
+      Subject.CollectArguments<{ a: Subject.Composable }>,
+      { a: Subject.Composable }
+    >
+  >
+  type testSubtypesForTwoComposables = Expect<
+    Equal<
+      Subject.CollectArguments<{
+        a: Subject.Composable<(x: string, y: 1) => void>
+        b: Subject.Composable<(x: 'foo', y: number) => void>
+      }>,
+      {
+        a: Subject.Composable<(x: 'foo', y: 1) => void>
+      } & {
+        b: Subject.Composable<(x: 'foo', y: 1) => void>
+      }
+    >
+  >
+  type testMaxArityForTwoComposables = Expect<
+    Equal<
+      Subject.CollectArguments<{
+        a: Subject.Composable<(x: string, y: number) => void>
+        b: Subject.Composable<(x: 'foo') => void>
+      }>,
+      {
+        a: Subject.Composable<(x: 'foo', y: number) => void>
+      } & {
+        b: Subject.Composable<(x: 'foo', y: number) => void>
+      }
+    >
+  >
+}
+
 describe('type tests', () =>
   it('should have no ts errors', () => assertEquals(true, true)))
 

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -168,11 +168,6 @@ namespace AllArguments {
   >
 }
 
-type x = Subject.CollectArguments<{
-  a: Subject.Composable<(x: string, y: 1) => void>
-  b: Subject.Composable<(x: 'foo', y: number) => void>
-}>
-
 namespace CollectArguments {
   type testNoEmptyArgumentList = Expect<
     Equal<Subject.CollectArguments<{}>, never>

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -101,7 +101,7 @@ namespace PipeArguments {
           Subject.Composable<(y: number, willBeUndefined: string) => boolean>,
         ]
       >,
-      ['Fail to compose ', undefined, ' does not fit in ', string]
+      ['Fail to compose', undefined, 'does not fit in', string]
     >
   >
   type testFailureToCompose = Expect<
@@ -112,7 +112,7 @@ namespace PipeArguments {
           Subject.Composable<(y: number) => boolean>,
         ]
       >,
-      ['Fail to compose ', void, ' does not fit in ', number]
+      ['Fail to compose', void, 'does not fit in', number]
     >
   >
 }
@@ -147,6 +147,22 @@ namespace AllArguments {
       [
         Subject.Composable<(x: 'foo', y: number) => void>,
         Subject.Composable<(x: 'foo', y: number) => void>,
+      ]
+    >
+  >
+  type testCompositionFailure = Expect<
+    Equal<
+      Subject.AllArguments<
+        [
+          Subject.Composable<(x: string, y: string) => void>,
+          Subject.Composable<(x: 'foo', y: number) => void>,
+        ]
+      >,
+      [
+        'Fail to compose',
+        [x: string, y: string],
+        'does not fit in',
+        [x: 'foo', y: number],
       ]
     >
   >
@@ -191,6 +207,20 @@ namespace CollectArguments {
       } & {
         b: Subject.Composable<(x: 'foo', y: number) => void>
       }
+    >
+  >
+  type testCompositionFailure = Expect<
+    Equal<
+      Subject.CollectArguments<{
+        a: Subject.Composable<(x: string, y: string) => void>
+        b: Subject.Composable<(x: 'foo', y: number) => void>
+      }>,
+      [
+        'Fail to compose',
+        [x: string, y: string],
+        'does not fit in',
+        [x: 'foo', y: number],
+      ]
     >
   >
 }

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -191,7 +191,6 @@ namespace CollectArguments {
       }>,
       {
         a: Subject.Composable<(x: 'foo', y: 1) => void>
-      } & {
         b: Subject.Composable<(x: 'foo', y: 1) => void>
       }
     >
@@ -204,7 +203,6 @@ namespace CollectArguments {
       }>,
       {
         a: Subject.Composable<(x: 'foo', y: number) => void>
-      } & {
         b: Subject.Composable<(x: 'foo', y: number) => void>
       }
     >

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -7,7 +7,7 @@ export type Equal<A, B> =
   // prettier is removing the parens thus worsening readability
   // prettier-ignore
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true
-    : [A, 'should equal', B]
+    : [A, "should equal", B]
 
 namespace MergeObjs {
   const obj1 = { a: 1, b: 2 } as const
@@ -215,6 +215,18 @@ namespace CollectArguments {
         [x: 'foo', y: number],
       ]
     >
+  >
+}
+
+namespace UnpackResult {
+  type testExtractsDataFromPromisedResult = Expect<
+    Equal<Subject.UnpackResult<Promise<Subject.Result<string>>>, string>
+  >
+}
+
+namespace UnpackAll {
+  type testExtractsDataFromPromisedResult = Expect<
+    Equal<Subject.UnpackAll<[Subject.Composable<() => string>]>, [string]>
   >
 }
 

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -60,6 +60,38 @@ namespace AtLeastOne {
   const error2: Result = { a: 1, c: 3 }
 }
 
+namespace PipeArguments {
+  type testNoEmptyArgumentList = Expect<Equal<Subject.PipeArguments<[]>, never>>
+  type testOneComposable = Expect<
+    Equal<Subject.PipeArguments<[Subject.Composable]>, [Subject.Composable]>
+  >
+  type testForTwoComposables = Expect<
+    Equal<
+      Subject.PipeArguments<
+        [
+          Subject.Composable<(x: string) => number>,
+          Subject.Composable<(y: number) => boolean>,
+        ]
+      >,
+      [
+        Subject.Composable<(x: string) => number>,
+        Subject.Composable<(y: number) => boolean>,
+      ]
+    >
+  >
+  type testFailureToCompose = Expect<
+    Equal<
+      Subject.PipeArguments<
+        [
+          Subject.Composable<(x: string) => void>,
+          Subject.Composable<(y: number) => boolean>,
+        ]
+      >,
+      ['Fail to compose ', void, ' does not fit in ', number]
+    >
+  >
+}
+
 namespace AllArguments {
   type testNoEmptyArgumentList = Expect<Equal<Subject.AllArguments<[]>, never>>
   type testOneComposable = Expect<

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -79,6 +79,17 @@ namespace PipeArguments {
       ]
     >
   >
+  type testForComponentsWithArityGreaterThan1 = Expect<
+    Equal<
+      Subject.PipeArguments<
+        [
+          Subject.Composable<(x: string) => number>,
+          Subject.Composable<(y: number, willBeUndefined: string) => boolean>,
+        ]
+      >,
+      ['Fail to compose ', undefined, ' does not fit in ', string]
+    >
+  >
   type testFailureToCompose = Expect<
     Equal<
       Subject.PipeArguments<

--- a/src/composable/types.test.ts
+++ b/src/composable/types.test.ts
@@ -79,6 +79,20 @@ namespace PipeArguments {
       ]
     >
   >
+  type testForComponentsWithArityGreaterThan1WithOptionalParameters = Expect<
+    Equal<
+      Subject.PipeArguments<
+        [
+          Subject.Composable<(x: string) => number>,
+          Subject.Composable<(y: number, optionalArgument?: string) => boolean>,
+        ]
+      >,
+      [
+        Subject.Composable<(x: string) => number>,
+        Subject.Composable<(y: number, optionalArgument?: string) => boolean>,
+      ]
+    >
+  >
   type testForComponentsWithArityGreaterThan1 = Expect<
     Equal<
       Subject.PipeArguments<

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -99,19 +99,12 @@ type PipeArguments<
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
   ? restA extends [
       Composable<
-        (firstParameter: infer FirstBParameter, ...b: infer PB) => infer OB
+        (firstParameter: infer FirstBParameter, ...b: infer PB) => any
       >,
-      ...infer restB,
     ]
     ? OA extends FirstBParameter
       ? EveryElementTakesUndefined<PB> extends true
-        ? PipeArguments<
-            [
-              Composable<(firstParameter: FirstBParameter, ...b: PB) => OB>,
-              ...restB,
-            ],
-            [...Arguments, Composable<(...a: PA) => OA>]
-          >
+        ? PipeArguments<restA, [...Arguments, Composable<(...a: PA) => OA>]>
         : EveryElementTakesUndefined<PB>
       : ['Fail to compose ', OA, ' does not fit in ', FirstBParameter]
     : [...Arguments, Composable<(...a: PA) => OA>]

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -97,15 +97,34 @@ type PipeArguments<
   Fns extends any[],
   Arguments extends any[] = [],
 > = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
-  ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
-    ? OA extends PB[0]
-      ? PipeArguments<
-          [Composable<(...args: PB) => OB>, ...restB],
-          [...Arguments, Composable<(...a: PA) => OA>]
-        >
-      : ['Fail to compose ', OA, ' does not fit in ', PB[0]]
+  ? restA extends [
+      Composable<
+        (firstParameter: infer FirstBParameter, ...b: infer PB) => infer OB
+      >,
+      ...infer restB,
+    ]
+    ? OA extends FirstBParameter
+      ? EveryElementTakesUndefined<PB> extends true
+        ? PipeArguments<
+            [
+              Composable<(firstParameter: FirstBParameter, ...b: PB) => OB>,
+              ...restB,
+            ],
+            [...Arguments, Composable<(...a: PA) => OA>]
+          >
+        : EveryElementTakesUndefined<PB>
+      : ['Fail to compose ', OA, ' does not fit in ', FirstBParameter]
     : [...Arguments, Composable<(...a: PA) => OA>]
   : never
+
+type EveryElementTakesUndefined<T extends any[]> = T extends [
+  infer HEAD,
+  ...infer TAIL,
+]
+  ? undefined extends HEAD
+    ? true & EveryElementTakesUndefined<TAIL>
+    : ['Fail to compose ', undefined, ' does not fit in ', HEAD]
+  : true
 
 type SubtypesTuple<
   TA extends unknown[],

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -88,7 +88,7 @@ type PipeReturn<Fns extends any[]> = Fns extends [
 ]
   ? OA extends PB
     ? PipeReturn<[Composable<(...args: PA) => OB>, ...rest]>
-    : ['Fail to compose ', OA, ' does not fit in ', PB]
+    : ['Fail to compose', OA, 'does not fit in', PB]
   : Fns extends [Composable<(...args: infer P) => infer O>]
   ? Composable<(...args: P) => O>
   : never
@@ -106,7 +106,7 @@ type PipeArguments<
       ? EveryElementTakesUndefined<PB> extends true
         ? PipeArguments<restA, [...Arguments, Composable<(...a: PA) => OA>]>
         : EveryElementTakesUndefined<PB>
-      : ['Fail to compose ', OA, ' does not fit in ', FirstBParameter]
+      : ['Fail to compose', OA, 'does not fit in', FirstBParameter]
     : [...Arguments, Composable<(...a: PA) => OA>]
   : never
 
@@ -116,7 +116,7 @@ type EveryElementTakesUndefined<T extends any[]> = T extends [
 ]
   ? undefined extends HEAD
     ? true & EveryElementTakesUndefined<TAIL>
-    : ['Fail to compose ', undefined, ' does not fit in ', HEAD]
+    : ['Fail to compose', undefined, 'does not fit in', HEAD]
   : true
 
 type SubtypesTuple<
@@ -145,7 +145,7 @@ type AllArguments<
           [Composable<(...args: MergedP) => OB>, ...restB],
           [...Arguments, Composable<(...a: MergedP) => OA>]
         >
-      : ['Fail to compose ', PA, ' does not fit in ', PB]
+      : ['Fail to compose', PA, 'does not fit in', PB]
     : [...Arguments, Composable<(...a: PA) => OA>]
   : never
 
@@ -186,7 +186,7 @@ type Zip<
       ? restK extends string[]
         ? restV extends Composable[]
           ? Zip<restK, restV, O & { [key in HeadK]: HeadV }>
-          : never
+          : V // in this case V has the AllArguments failure type
         : never
       : never
     : O

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -199,8 +199,6 @@ type CollectArguments<T extends Record<string, Composable>> = {} extends Zip<
   ? never
   : Prettify<Zip<Keys<T>, AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>>>
 
-type X = {} extends undefined ? true : false
-
 type RecordToTuple<T extends Record<string, Composable>> =
   RecordValuesFromKeysTuple<T, Keys<T>>
 

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -96,33 +96,15 @@ type PipeReturn<Fns extends any[]> = Fns extends [
 type PipeArguments<
   Fns extends any[],
   Arguments extends any[] = [],
-> = Fns extends [
-  Composable<(...a: infer PA) => infer OA>,
-  Composable<(...b: infer PB) => infer OB>,
-  ...infer rest,
-]
-  ? OA extends PB[0]
-    ? rest extends []
-      ? [
-          ...Arguments,
-          Composable<(...a: PA) => OA>,
-          Composable<(...b: PB) => OB>,
-        ]
-      : PipeArguments<
-          [Composable<(...args: PA) => OB>, ...rest],
-          [
-            ...Arguments,
-            Composable<(...a: PA) => OA>,
-            Composable<(...b: PB) => OB>,
-          ]
+> = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
+  ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
+    ? OA extends PB[0]
+      ? PipeArguments<
+          [Composable<(...args: PB) => OB>, ...restB],
+          [...Arguments, Composable<(...a: PA) => OA>]
         >
-    : ['Fail to compose ', PA, ' does not fit in ', PB[0]]
-  : Fns extends [Composable, ...infer rest]
-  ? rest extends []
-    ? Arguments
-    : Fns
-  : Fns extends []
-  ? []
+      : ['Fail to compose ', OA, ' does not fit in ', PB[0]]
+    : [...Arguments, Composable<(...a: PA) => OA>]
   : never
 
 type SubtypesTuple<
@@ -227,3 +209,4 @@ export type {
   UnpackAll,
   UnpackResult,
 }
+

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -17,12 +17,12 @@ type ErrorWithMessage = {
   exception?: unknown
 }
 type Failure = {
-  success: false,
+  success: false
   errors: Array<ErrorWithMessage>
 }
 type Success<T> = {
-  success: true,
-  data: T,
+  success: true
+  data: T
   errors: []
 }
 type Result<T> = Success<T> | Failure
@@ -81,20 +81,149 @@ type TupleToUnion<T extends unknown[]> = T[number]
  */
 type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U]
 
+type PipeReturn<Fns extends any[]> = Fns extends [
+  Composable<(...a: infer PA) => infer OA>,
+  Composable<(b: infer PB) => infer OB>,
+  ...infer rest,
+]
+  ? OA extends PB
+    ? PipeReturn<[Composable<(...args: PA) => OB>, ...rest]>
+    : ['Fail to compose ', OA, ' does not fit in ', PB]
+  : Fns extends [Composable<(...args: infer P) => infer O>]
+  ? Composable<(...args: P) => O>
+  : never
+
+type PipeArguments<
+  Fns extends any[],
+  Arguments extends any[] = [],
+> = Fns extends [
+  Composable<(...a: infer PA) => infer OA>,
+  Composable<(...b: infer PB) => infer OB>,
+  ...infer rest,
+]
+  ? OA extends PB[0]
+    ? rest extends []
+      ? [
+          ...Arguments,
+          Composable<(...a: PA) => OA>,
+          Composable<(...b: PB) => OB>,
+        ]
+      : PipeArguments<
+          [Composable<(...args: PA) => OB>, ...rest],
+          [
+            ...Arguments,
+            Composable<(...a: PA) => OA>,
+            Composable<(...b: PB) => OB>,
+          ]
+        >
+    : ['Fail to compose ', PA, ' does not fit in ', PB[0]]
+  : Fns extends [Composable, ...infer rest]
+  ? rest extends []
+    ? Arguments
+    : Fns
+  : Fns extends []
+  ? []
+  : never
+
+type SubtypesTuple<
+  TA extends unknown[],
+  TB extends unknown[],
+  O extends unknown[],
+> = TA extends [infer headA, ...infer restA]
+  ? TB extends [infer headB, ...infer restB]
+    ? headA extends headB
+      ? SubtypesTuple<restA, restB, [...O, headA]>
+      : headB extends headA
+      ? SubtypesTuple<restA, restB, [...O, headB]>
+      : { 'Incompatible arguments ': true; argument1: headA; argument2: headB }
+    : SubtypesTuple<restA, [], [...O, headA]>
+  : TB extends [infer headBNoA, ...infer restBNoA]
+  ? SubtypesTuple<[], restBNoA, [...O, headBNoA]>
+  : O
+
+type AllArguments<
+  Fns extends any[],
+  Arguments extends any[] = [],
+> = Fns extends [Composable<(...a: infer PA) => infer OA>, ...infer restA]
+  ? restA extends [Composable<(...b: infer PB) => infer OB>, ...infer restB]
+    ? SubtypesTuple<PA, PB, []> extends [...infer MergedP]
+      ? AllArguments<
+          [Composable<(...args: MergedP) => OB>, ...restB],
+          [...Arguments, Composable<(...a: MergedP) => OA>]
+        >
+      : ['Fail to compose ', PA, ' does not fit in ', PB]
+    : [...Arguments, Composable<(...a: PA) => OA>]
+  : never
+
+// Thanks to https://github.com/tjjfvi
+// UnionToTuple code lifted from this thread: https://github.com/microsoft/TypeScript/issues/13298#issuecomment-707364842
+// This will not preserve union order but we don't care since this is for Composable paralel application
+type UnionToTuple<T> = (
+  (T extends any ? (t: T) => T : never) extends infer U
+    ? (U extends any ? (u: U) => any : never) extends (v: infer V) => any
+      ? V
+      : never
+    : never
+) extends (_: any) => infer W
+  ? [...UnionToTuple<Exclude<T, W>>, W]
+  : []
+
+type Keys<R extends Record<string, any>> = UnionToTuple<keyof R>
+
+type RecordValuesFromKeysTuple<
+  R extends Record<string, Composable>,
+  K extends unknown[],
+  ValuesTuple extends Composable[] = [],
+> = K extends [infer Head, ...infer rest]
+  ? Head extends string
+    ? rest extends string[]
+      ? RecordValuesFromKeysTuple<R, rest, [...ValuesTuple, R[Head]]>
+      : never
+    : ValuesTuple
+  : ValuesTuple
+
+type Zip<
+  K extends unknown[],
+  V extends Composable[],
+  O extends Record<string, Composable> = {},
+> = K extends [infer HeadK, ...infer restK]
+  ? V extends [infer HeadV, ...infer restV]
+    ? HeadK extends string
+      ? restK extends string[]
+        ? restV extends Composable[]
+          ? Zip<restK, restV, O & { [key in HeadK]: HeadV }>
+          : never
+        : never
+      : never
+    : O
+  : O
+
+type CollectArguments<T extends Record<string, Composable>> = Zip<
+  Keys<T>,
+  AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>
+>
+
+type RecordToTuple<T extends Record<string, Composable>> =
+  RecordValuesFromKeysTuple<T, Keys<T>>
 
 export type {
+  AllArguments,
   AtLeastOne,
+  CollectArguments,
   Composable,
   ErrorWithMessage,
+  Failure,
   First,
   Fn,
   Last,
   MergeObjs,
+  PipeArguments,
+  PipeReturn,
   Prettify,
+  RecordToTuple,
   Result,
+  Success,
   TupleToUnion,
   UnpackAll,
   UnpackResult,
-  Success,
-  Failure
 }

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -197,7 +197,7 @@ type CollectArguments<T extends Record<string, Composable>> = {} extends Zip<
   AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>
 >
   ? never
-  : Zip<Keys<T>, AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>>
+  : Prettify<Zip<Keys<T>, AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>>>
 
 type X = {} extends undefined ? true : false
 

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -192,10 +192,14 @@ type Zip<
     : O
   : O
 
-type CollectArguments<T extends Record<string, Composable>> = Zip<
+type CollectArguments<T extends Record<string, Composable>> = {} extends Zip<
   Keys<T>,
   AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>
 >
+  ? never
+  : Zip<Keys<T>, AllArguments<RecordValuesFromKeysTuple<T, Keys<T>>>>
+
+type X = {} extends undefined ? true : false
 
 type RecordToTuple<T extends Record<string, Composable>> =
   RecordValuesFromKeysTuple<T, Keys<T>>

--- a/src/constructor.ts
+++ b/src/constructor.ts
@@ -6,7 +6,7 @@ import type {
   SchemaError,
 } from './types.ts'
 import { Composable } from './composable/index.ts'
-import { λ } from './composable/composable.ts'
+import { composable } from './composable/composable.ts'
 
 function dfResultFromcomposable<T extends Composable, R>(fn: T) {
   return (async (...args) => {
@@ -45,7 +45,7 @@ function makeDomainFunction<I, E>(
 ) {
   return function <Output>(handler: (input: I, environment: E) => Output) {
     return fromComposable(
-      λ(handler),
+      composable(handler),
       inputSchema,
       environmentSchema,
     ) as DomainFunction<Awaited<Output>>

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -215,7 +215,7 @@ function sequence<Fns extends DomainFunction[]>(
   return function (input: unknown, environment?: unknown) {
     const dfsAsComposable = fns.map((df) =>
       A.composable(fromSuccess(applyEnvironment(df, environment))),
-    ) as [Composable, ...Composable[]]
+    )
     return dfResultFromcomposable(
       A.sequence(...(dfsAsComposable as [Composable])),
     )(input)

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -37,7 +37,7 @@ import { Composable } from './index.ts'
  * }
  */
 function safeResult<T>(fn: () => T): Promise<Result<T>> {
-  return dfResultFromcomposable(A.λ(fn))() as Promise<Result<T>>
+  return dfResultFromcomposable(A.composable(fn))() as Promise<Result<T>>
 }
 
 /**
@@ -72,7 +72,7 @@ function all<Fns extends DomainFunction[]>(
 ): DomainFunction<UnpackAll<Fns>> {
   return ((input, environment) => {
     const [first, ...rest] = fns.map((df) =>
-      A.λ(() => fromSuccess(df)(input, environment)),
+      A.composable(() => fromSuccess(df)(input, environment)),
     )
     return dfResultFromcomposable(A.all(first, ...rest))()
   }) as DomainFunction<UnpackAll<Fns>>
@@ -214,7 +214,7 @@ function sequence<Fns extends DomainFunction[]>(
 ): DomainFunction<UnpackAll<Fns>> {
   return function (input: unknown, environment?: unknown) {
     const dfsAsComposable = fns.map((df) =>
-      A.λ(fromSuccess(applyEnvironment(df, environment))),
+      A.composable(fromSuccess(applyEnvironment(df, environment))),
     ) as [Composable, ...Composable[]]
     return (dfResultFromcomposable(A.sequence(...dfsAsComposable)))(
       input,
@@ -238,7 +238,7 @@ function map<O, R>(
   return ((input, environment) =>
     dfResultFromcomposable(
       A.map(
-        A.λ(() => fromSuccess(dfn)(input, environment)),
+        A.composable(() => fromSuccess(dfn)(input, environment)),
         mapper,
       ),
     )()) as DomainFunction<R>

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -15,6 +15,7 @@ import type {
 } from './types.ts'
 import { dfResultFromcomposable } from './constructor.ts'
 import { toErrorWithMessage } from './composable/errors.ts'
+import { Composable } from './index.ts'
 
 /**
  * A functions that turns the result of its callback into a Result object.
@@ -212,12 +213,12 @@ function sequence<Fns extends DomainFunction[]>(
   ...fns: Fns
 ): DomainFunction<UnpackAll<Fns>> {
   return function (input: unknown, environment?: unknown) {
-    const [first, ...rest] = fns.map((df) =>
+    const dfsAsComposable = fns.map((df) =>
       A.λ(fromSuccess(applyEnvironment(df, environment))),
+    ) as [Composable, ...Composable[]]
+    return (dfResultFromcomposable(A.sequence(...dfsAsComposable)))(
+      input,
     )
-    return (
-      dfResultFromcomposable(A.sequence(...([first, ...rest] as any))) as any
-    )(input)
   } as DomainFunction<UnpackAll<Fns>>
 }
 

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -215,7 +215,9 @@ function sequence<Fns extends DomainFunction[]>(
     const [first, ...rest] = fns.map((df) =>
       A.λ(fromSuccess(applyEnvironment(df, environment))),
     )
-    return dfResultFromcomposable(A.sequence(first, ...rest))(input)
+    return (
+      dfResultFromcomposable(A.sequence(...([first, ...rest] as any))) as any
+    )(input)
   } as DomainFunction<UnpackAll<Fns>>
 }
 

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -74,7 +74,7 @@ function all<Fns extends DomainFunction[]>(
     const composables = fns.map((df) =>
       A.composable(() => fromSuccess(df)(input, environment)),
     )
-    return dfResultFromcomposable(A.all(...composables as any))()
+    return dfResultFromcomposable(A.all(...(composables as [Composable])))()
   }) as DomainFunction<UnpackAll<Fns>>
 }
 
@@ -216,9 +216,9 @@ function sequence<Fns extends DomainFunction[]>(
     const dfsAsComposable = fns.map((df) =>
       A.composable(fromSuccess(applyEnvironment(df, environment))),
     ) as [Composable, ...Composable[]]
-    return (dfResultFromcomposable(A.sequence(...dfsAsComposable)))(
-      input,
-    )
+    return dfResultFromcomposable(
+      A.sequence(...(dfsAsComposable as [Composable])),
+    )(input)
   } as DomainFunction<UnpackAll<Fns>>
 }
 

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -71,10 +71,10 @@ function all<Fns extends DomainFunction[]>(
   ...fns: Fns
 ): DomainFunction<UnpackAll<Fns>> {
   return ((input, environment) => {
-    const [first, ...rest] = fns.map((df) =>
+    const composables = fns.map((df) =>
       A.composable(() => fromSuccess(df)(input, environment)),
     )
-    return dfResultFromcomposable(A.all(first, ...rest))()
+    return dfResultFromcomposable(A.all(...composables as any))()
   }) as DomainFunction<UnpackAll<Fns>>
 }
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,18 +1,17 @@
 // deno-lint-ignore-file ban-ts-comment no-namespace no-unused-vars
 import { mdf } from './constructor.ts'
-import { describe, it, assertEquals } from './test-prelude.ts'
+import { assertEquals, describe, it } from './test-prelude.ts'
 import * as Subject from './types.ts'
 
 export type Expect<T extends true> = T
 export type Equal<A, B> =
   // prettier is removing the parens thus worsening readability
   // prettier-ignore
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
-    ? true
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true
     : false
 
 namespace UnpackData {
-  const result = mdf()(() => ({ name: 'foo' } as const))
+  const result = mdf()(() => ({ name: 'foo' }) as const)
 
   type test = Expect<
     Equal<Subject.UnpackData<typeof result>, { readonly name: 'foo' }>
@@ -78,8 +77,8 @@ namespace AtLeastOne {
 }
 
 namespace UnpackAll {
-  const dfA = mdf()(() => ({ a: 1 } as const))
-  const dfB = mdf()(() => ({ b: 2 } as const))
+  const dfA = mdf()(() => ({ a: 1 }) as const)
+  const dfB = mdf()(() => ({ b: 2 }) as const)
 
   type Result = Subject.UnpackAll<[typeof dfA, typeof dfB]>
 
@@ -88,3 +87,4 @@ namespace UnpackAll {
 
 describe('type tests', () =>
   it('should have no ts errors', () => assertEquals(true, true)))
+


### PR DESCRIPTION
This should allow only valid types when using the composition primitives (a.k.a. `Composable` operations).
Since the primitives do not have parsers on their input the type-safety not only makes sense but becomes essential to writing robust compositions.

It is important to note that we rely on a type conversion from a union to a tuple. This type helper (generously shared [here](https://github.com/microsoft/TypeScript/issues/13298#issuecomment-707364842)) uses the internal union order which means that the order when converting from a `Record` to a tuple is not stable. This is irrelevant to type our `collect` function since it is applied in parallel. But I'm leaving this long note here to explain why implementing a `collectSequence` with a Record input would be very challenging.