### PR TITLE
Do not error when passing parameters to a DF created with makeDomainFunction()

### DIFF
--- a/src/constructor.test.ts
+++ b/src/constructor.test.ts
@@ -68,13 +68,14 @@ describe('makeDomainFunction', () => {
     })
 
     it('fails gracefully if gets something other than undefined', async () => {
-      const handler = mdf()(() => 'no input!')
-      type _R = Expect<Equal<typeof handler, DomainFunction<string>>>
+      const handler = mdf()((args) => args)
+      type _R = Expect<Equal<typeof handler, DomainFunction<undefined>>>
 
       assertEquals(await handler('some input'), {
-        success: false,
+        success: true,
+        data: undefined,
         errors: [],
-        inputErrors: [{ path: [], message: 'Expected undefined' }],
+        inputErrors: [],
         environmentErrors: [],
       })
     })

--- a/src/constructor.test.ts
+++ b/src/constructor.test.ts
@@ -67,7 +67,7 @@ describe('makeDomainFunction', () => {
       })
     })
 
-    it('fails gracefully if gets something other than undefined', async () => {
+    it('ignores the input and pass undefined', async () => {
       const handler = mdf()((args) => args)
       type _R = Expect<Equal<typeof handler, DomainFunction<undefined>>>
 

--- a/src/constructor.ts
+++ b/src/constructor.ts
@@ -39,7 +39,7 @@ function formatSchemaErrors(errors: ParserIssue[]): SchemaError[] {
  *   return { message: `${greeting} ${user.name}` }
  * })
  */
-function makeDomainFunction<I, E>(
+function makeDomainFunction<I = undefined, E = Record<PropertyKey, unknown>>(
   inputSchema?: ParserSchema<I>,
   environmentSchema?: ParserSchema<E>,
 ) {
@@ -104,14 +104,8 @@ const objectSchema: ParserSchema<Record<PropertyKey, unknown>> = {
 }
 
 const undefinedSchema: ParserSchema<undefined> = {
-  safeParseAsync: (data: unknown) => {
-    if (data !== undefined) {
-      return Promise.resolve({
-        success: false,
-        error: { issues: [{ path: [], message: 'Expected undefined' }] },
-      })
-    }
-    return Promise.resolve({ success: true, data })
+  safeParseAsync: (_data: unknown) => {
+    return Promise.resolve({ success: true, data: undefined })
   },
 }
 


### PR DESCRIPTION
Based on [this discussion](https://github.com/seasonedcc/domain-functions/discussions/122)
Note that this is a breaking change, even though unlikely, someone might be relying on the error of an undefined parser.

I think it is a nicer default behaviour though. And the previous behaviour is easy to reproduce by passing a `z.undefined()`. We can add this note on the release.

