### PR TITLE
New sequenceAll combinator

### DIFF
--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -172,7 +172,7 @@ function sequence<T extends [Composable, ...Composable[]]>(
  * @example
  * import { composable as C } from 'domain-functions'
  *
- * const a = C.composable((something: unknown) => String(something))
+ * const a = C.composable((something: unknown) => Number(something))
  * const b = C.composable((aString: string) => aString === '1')
  * const cf = C.sequenceAll(a, b)
  * //    ^? Composable<(aString: string) => [string, boolean]>


### PR DESCRIPTION
## Use case

This fits a similar use case as the passthrough proposed on #96
It can be used to add validation functions to a pipeline that should abort execution on error but don't necessarly produce a result that we want to pipe to the next callee.

For instance, let's say you want to check the state of a record in the database and send a notification only when the validation function is successful.
In this case the resulting type of the validation function should not be taken into account, since you don't want to write the function for the composition.

With the new combinator something like this could be done:
```typescript
const isValidInDatabase = composable(id: string) => { ... }
const sendNotification = composable(id: string) => { ... }
const sendNotificationWhenValid = sequenceAll(isValidInDatabase, sendNotification)
```

It also makes it easier to reuse existing functions just for the sake of their side-effects. On the previous example, let's say you want add a function that records a log of messages sent on the database (and fail to send the message in case the log fails).

I was hoping to merge this before we have the full composable documentation.

## TODO

- [ ] Add DomainFunction version of the combinator
- [ ] Add README documentation for DomainFunction.
