### PR TITLE
Fix composable pipe for async functions

### DIFF
--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -79,6 +79,22 @@ describe('pipe', () => {
     assertEquals(res, { success: true, data: '3', errors: [] })
   })
 
+  it('sends the results of the first function to the second and infers types', async () => {
+    const asyncProduceToIncrement = composable(() =>
+      Promise.resolve({ toIncrement: 1, someOtherProperty: 'test' }))
+    const asyncIncrementProperty = composable((a: { toIncrement: number }) =>
+      Promise.resolve(a.toIncrement + 1))
+    const fn = pipe(asyncProduceToIncrement, asyncIncrementProperty)
+    const res = await fn()
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<() => number>>
+    >
+    type _R = Expect<Equal<typeof res, Result<number>>>
+
+    assertEquals(res, { success: true, data: 2, errors: [] })
+  })
+
   it('catches the errors from function A', async () => {
     const fn = pipe(faultyAdd, toString)
     const res = await fn(1, 2)


### PR DESCRIPTION
The types `PipeArguments` and `PipeReturn` were not taking into account async composables (the runtime already had the proper awaits though).

The fix using `Awaited` caused functions returning never to type check, so I introduced the `IsNever` and handled those cases separately. 
