### PR TITLE
Simplify error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The error result has the following structure:
 ```ts
 type ErrorResult = {
   success: false
-  errors: ErrorWithMessage[]
+  errors: Error[]
   inputErrors: SchemaError[]
   environmentErrors: SchemaError[]
 }

--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -76,7 +76,7 @@ describe('all', () => {
 
     assertEquals(await c({ id: 1 }), {
       success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
+      errors: [new Error()],
       inputErrors: [],
       environmentErrors: [],
     })

--- a/src/collect.test.ts
+++ b/src/collect.test.ts
@@ -1,8 +1,8 @@
 import {
+  assertEquals,
+  assertObjectMatch,
   describe,
   it,
-  assertObjectMatch,
-  assertEquals,
 } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
@@ -59,7 +59,7 @@ describe('collect', () => {
 
     assertEquals(await c({ id: 1 }), {
       success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
+      errors: [new Error('Error')],
       inputErrors: [],
       environmentErrors: [],
     })
@@ -102,10 +102,7 @@ describe('collect', () => {
 
     assertObjectMatch(await c({ id: 1 }), {
       success: false,
-      errors: [
-        { message: 'Error A', exception: { message: 'Error A' } },
-        { message: 'Error B', exception: { message: 'Error B' } },
-      ],
+      errors: [{ message: 'Error A' }, { message: 'Error B' }],
       inputErrors: [],
       environmentErrors: [],
     })

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -1,9 +1,8 @@
-import { toErrorWithMessage } from './errors.ts'
+import { toError } from './errors.ts'
 import {
   AllArguments,
   CollectArguments,
   Composable,
-  ErrorWithMessage,
   Failure,
   First,
   Fn,
@@ -36,7 +35,7 @@ function success<T>(data: T): Success<T> {
   return { success: true, data, errors: [] }
 }
 
-function error(errors: ErrorWithMessage[]): Failure {
+function error(errors: Error[]): Failure {
   return { success: false, errors }
 }
 
@@ -52,7 +51,7 @@ function composable<T extends Fn>(fn: T): Composable<T> {
       const result = await fn(...(args as any[]))
       return success(result)
     } catch (e) {
-      return error([toErrorWithMessage(e)])
+      return error([toError(e)])
     }
   }
 }
@@ -226,4 +225,3 @@ export {
   sequence,
   success,
 }
-

--- a/src/composable/errors.ts
+++ b/src/composable/errors.ts
@@ -23,12 +23,9 @@ function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
  * }
  */
 function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
-  return {
-    message: isErrorWithMessage(maybeError)
-      ? maybeError.message
-      : String(maybeError),
-    exception: maybeError,
-  }
+  return isErrorWithMessage(maybeError)
+    ? maybeError
+    : new Error(String(maybeError))
 }
 
 export { toErrorWithMessage }

--- a/src/composable/errors.ts
+++ b/src/composable/errors.ts
@@ -1,5 +1,3 @@
-import { ErrorWithMessage } from './types.ts'
-
 function objectHasKey<T extends string>(
   obj: unknown,
   key: T,
@@ -7,25 +5,23 @@ function objectHasKey<T extends string>(
   return typeof obj === 'object' && obj !== null && key in obj
 }
 
-function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+function isError(error: unknown): error is Error {
   return objectHasKey(error, 'message') && typeof error.message === 'string'
 }
 
 /**
- * Turns the given 'unknown' error into an ErrorWithMessage.
- * @param maybeError the error to turn into an ErrorWithMessage
- * @returns the ErrorWithMessage
+ * Turns the given 'unknown' error into an Error.
+ * @param maybeError the error to turn into an Error
+ * @returns the Error
  * @example
  * try {}
  * catch (error) {
- *   const errorWithMessage = toErrorWithMessage(error)
- *   console.log(errorWithMessage.message)
+ *   const Error = toError(error)
+ *   console.log(Error.message)
  * }
  */
-function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
-  return isErrorWithMessage(maybeError)
-    ? maybeError
-    : new Error(String(maybeError))
+function toError(maybeError: unknown): Error {
+  return isError(maybeError) ? maybeError : new Error(String(maybeError))
 }
 
-export { toErrorWithMessage }
+export { toError }

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -124,7 +124,7 @@ describe('pipe', () => {
     assertEquals(res.errors![0].message, 'always throw')
     assertEquals(
       // deno-lint-ignore no-explicit-any
-      (res.errors[0] as any).exception?.cause,
+      (res.errors[0] as any).cause,
       'it was made for this',
     )
   })

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -349,6 +349,7 @@ describe('map', () => {
 })
 
 const cleanError = (err: ErrorWithMessage) => ({
+  ...err,
   message: err.message + '!!!',
 })
 describe('mapError', () => {
@@ -382,4 +383,3 @@ describe('mapError', () => {
     assertEquals(res.errors![0].message, 'Mapper also has problems')
   })
 })
-

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, describe, it } from '../test-prelude.ts'
 import { map, mapError, pipe, sequence } from './index.ts'
-import type { Composable, ErrorWithMessage, Result } from './index.ts'
+import type { Composable, Result } from './index.ts'
 import { Equal, Expect } from './types.test.ts'
 import { all, collect, composable } from './composable.ts'
 
@@ -348,7 +348,7 @@ describe('map', () => {
   })
 })
 
-const cleanError = (err: ErrorWithMessage) => ({
+const cleanError = (err: Error) => ({
   ...err,
   message: err.message + '!!!',
 })

--- a/src/composable/index.ts
+++ b/src/composable/index.ts
@@ -1,3 +1,11 @@
-export type { Composable, Result, ErrorWithMessage } from './types.ts'
-export { toErrorWithMessage } from './errors.ts'
-export { composable, pipe, map, mapError, sequence, all, collect } from './composable.ts'
+export type { Composable, Result } from './types.ts'
+export { toError } from './errors.ts'
+export {
+  composable,
+  pipe,
+  map,
+  mapError,
+  sequence,
+  all,
+  collect,
+} from './composable.ts'

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -19,10 +19,9 @@ type IsNever<A> =
 type First<T extends readonly any[]> = T extends [infer F, ...infer _I]
   ? F
   : never
-type ErrorWithMessage = {
-  message: string
-  exception: unknown
-}
+
+type ErrorWithMessage = Error
+
 type Failure = {
   success: false
   errors: Array<ErrorWithMessage>
@@ -234,4 +233,3 @@ export type {
   UnpackAll,
   UnpackResult,
 }
-

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -21,7 +21,7 @@ type First<T extends readonly any[]> = T extends [infer F, ...infer _I]
   : never
 type ErrorWithMessage = {
   message: string
-  exception?: unknown
+  exception: unknown
 }
 type Failure = {
   success: false

--- a/src/composable/types.ts
+++ b/src/composable/types.ts
@@ -20,11 +20,9 @@ type First<T extends readonly any[]> = T extends [infer F, ...infer _I]
   ? F
   : never
 
-type ErrorWithMessage = Error
-
 type Failure = {
   success: false
-  errors: Array<ErrorWithMessage>
+  errors: Array<Error>
 }
 type Success<T> = {
   success: true
@@ -217,7 +215,6 @@ export type {
   AtLeastOne,
   CollectArguments,
   Composable,
-  ErrorWithMessage,
   Failure,
   First,
   Fn,

--- a/src/constructor.test.ts
+++ b/src/constructor.test.ts
@@ -30,7 +30,7 @@ describe('toComposable', () => {
 
     assertEquals(await c(), {
       success: false,
-      errors: [{ message: 'Required', exception: new Error('Required') }],
+      errors: [new Error('Required')],
     })
   })
 
@@ -227,10 +227,7 @@ describe('makeDomainFunction', () => {
       errors: [
         {
           message: 'Some message',
-          exception: {
-            message: 'Some message',
-            cause: { someUnknownFields: true },
-          },
+          cause: { someUnknownFields: true },
         },
       ],
       inputErrors: [],
@@ -246,7 +243,7 @@ describe('makeDomainFunction', () => {
 
     assertObjectMatch(await handler({ id: 1 }), {
       success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
+      errors: [{ message: 'Error' }],
       inputErrors: [],
       environmentErrors: [],
     })
@@ -258,9 +255,9 @@ describe('makeDomainFunction', () => {
     })
     type _R = Expect<Equal<typeof handler, DomainFunction<never>>>
 
-    assertEquals(await handler({ id: 1 }), {
+    assertObjectMatch(await handler({ id: 1 }), {
       success: false,
-      errors: [{ message: 'Error', exception: { message: 'Error' } }],
+      errors: [{ message: 'Error' }],
       inputErrors: [],
       environmentErrors: [],
     })

--- a/src/constructor.test.ts
+++ b/src/constructor.test.ts
@@ -30,7 +30,7 @@ describe('toComposable', () => {
 
     assertEquals(await c(), {
       success: false,
-      errors: [{ message: 'Required' }],
+      errors: [{ message: 'Required', exception: new Error('Required') }],
     })
   })
 
@@ -336,4 +336,3 @@ describe('makeDomainFunction', () => {
     })
   })
 })
-

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -14,7 +14,7 @@ import type {
   UnpackResult,
 } from './types.ts'
 import { dfResultFromcomposable } from './constructor.ts'
-import { toErrorWithMessage } from './composable/errors.ts'
+import { toError } from './composable/errors.ts'
 import { Composable } from './index.ts'
 
 /**
@@ -373,7 +373,7 @@ function trace<D extends DomainFunction = DomainFunction<unknown>>(
       >)
       return result
     } catch (e) {
-      return failureToErrorResult(A.error([toErrorWithMessage(e)]))
+      return failureToErrorResult(A.error([toError(e)]))
     }
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,11 @@
-import { Failure } from './composable/types.ts'
+import { Failure } from "./composable/types.ts";
 import type {
   AtLeastOne,
   ErrorData,
   ErrorResult,
   ErrorWithMessage,
   SchemaError,
-} from './types.ts'
+} from "./types.ts";
 
 /**
  * Creates a SchemaError (used in inputErrors and environmentErrors) from the given message and path.
@@ -14,7 +14,7 @@ import type {
  * @returns the SchemaError
  */
 function schemaError(message: string, path: string): SchemaError {
-  return { message, path: path.split('.') }
+  return { message, path: path.split(".") };
 }
 
 /**
@@ -25,8 +25,8 @@ function schemaError(message: string, path: string): SchemaError {
  */
 function errorMessagesFor(errors: SchemaError[], name: string) {
   return errors
-    .filter(({ path }) => path.join('.') === name)
-    .map(({ message }) => message)
+    .filter(({ path }) => path.join(".") === name)
+    .map(({ message }) => message);
 }
 
 /**
@@ -37,21 +37,21 @@ function errorMessagesFor(errors: SchemaError[], name: string) {
  * })
  */
 class InputError extends Error {
-  path: string
+  path: string;
 
   constructor(message: string, path: string) {
-    super(message)
-    this.name = 'InputError'
-    this.path = path
+    super(message);
+    this.name = "InputError";
+    this.path = path;
   }
 }
 
 class InputErrors extends Error {
-  errors: { message: string; path: string }[]
+  errors: { message: string; path: string }[];
 
   constructor(errors: { message: string; path: string }[]) {
-    super(`${errors.length} errors`)
-    this.errors = errors
+    super(`${errors.length} errors`);
+    this.errors = errors;
   }
 }
 
@@ -63,12 +63,12 @@ class InputErrors extends Error {
  * })
  */
 class EnvironmentError extends Error {
-  path: string
+  path: string;
 
   constructor(message: string, path: string) {
-    super(message)
-    this.name = 'EnvironmentError'
-    this.path = path
+    super(message);
+    this.name = "EnvironmentError";
+    this.path = path;
   }
 }
 
@@ -83,25 +83,27 @@ class EnvironmentError extends Error {
  * })
  */
 class ResultError extends Error {
-  result: ErrorResult
+  result: ErrorResult;
 
   constructor(result: AtLeastOne<ErrorData>) {
-    super('ResultError')
-    this.name = 'ResultError'
+    super("ResultError");
+    this.name = "ResultError";
     this.result = {
       errors: [],
       inputErrors: [],
       environmentErrors: [],
       ...result,
       success: false,
-    }
+    };
   }
 }
 
 function schemaErrorToErrorWithMessage(se: SchemaError): ErrorWithMessage {
+  const message = `${se.path.join(".")} ${se.message}`.trim();
   return {
-    message: `${se.path.join('.')} ${se.message}`.trim(),
-  }
+    message,
+    exception: new Error(message),
+  };
 }
 function errorResultToFailure({
   errors,
@@ -115,7 +117,7 @@ function errorResultToFailure({
       ...inputErrors.map(schemaErrorToErrorWithMessage),
       ...environmentErrors.map(schemaErrorToErrorWithMessage),
     ],
-  }
+  };
 }
 
 function failureToErrorResult({ errors }: Failure): ErrorResult {
@@ -131,38 +133,38 @@ function failureToErrorResult({ errors }: Failure): ErrorResult {
           ),
       )
       .flatMap((e) =>
-        e.exception instanceof ResultError ? e.exception.result.errors : e,
+        e.exception instanceof ResultError ? e.exception.result.errors : e
       ),
     inputErrors: errors.flatMap(({ exception }) =>
       exception instanceof InputError
         ? [
-            {
-              path: exception.path.split('.'),
-              message: exception.message,
-            },
-          ]
+          {
+            path: exception.path.split("."),
+            message: exception.message,
+          },
+        ]
         : exception instanceof InputErrors
         ? exception.errors.map((e) => ({
-            path: e.path.split('.'),
-            message: e.message,
-          }))
+          path: e.path.split("."),
+          message: e.message,
+        }))
         : exception instanceof ResultError
         ? exception.result.inputErrors
-        : [],
+        : []
     ),
     environmentErrors: errors.flatMap(({ exception }) =>
       exception instanceof EnvironmentError
         ? [
-            {
-              path: exception.path.split('.'),
-              message: exception.message,
-            },
-          ]
+          {
+            path: exception.path.split("."),
+            message: exception.message,
+          },
+        ]
         : exception instanceof ResultError
         ? exception.result.environmentErrors
-        : [],
+        : []
     ),
-  }
+  };
 }
 
 export {
@@ -174,5 +176,4 @@ export {
   InputErrors,
   ResultError,
   schemaError,
-}
-
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,11 @@
-import { Failure } from "./composable/types.ts";
+import { Failure } from './composable/types.ts'
 import type {
   AtLeastOne,
   ErrorData,
   ErrorResult,
   ErrorWithMessage,
   SchemaError,
-} from "./types.ts";
+} from './types.ts'
 
 /**
  * Creates a SchemaError (used in inputErrors and environmentErrors) from the given message and path.
@@ -14,7 +14,7 @@ import type {
  * @returns the SchemaError
  */
 function schemaError(message: string, path: string): SchemaError {
-  return { message, path: path.split(".") };
+  return { message, path: path.split('.') }
 }
 
 /**
@@ -25,8 +25,8 @@ function schemaError(message: string, path: string): SchemaError {
  */
 function errorMessagesFor(errors: SchemaError[], name: string) {
   return errors
-    .filter(({ path }) => path.join(".") === name)
-    .map(({ message }) => message);
+    .filter(({ path }) => path.join('.') === name)
+    .map(({ message }) => message)
 }
 
 /**
@@ -37,21 +37,21 @@ function errorMessagesFor(errors: SchemaError[], name: string) {
  * })
  */
 class InputError extends Error {
-  path: string;
+  path: string
 
   constructor(message: string, path: string) {
-    super(message);
-    this.name = "InputError";
-    this.path = path;
+    super(message)
+    this.name = 'InputError'
+    this.path = path
   }
 }
 
 class InputErrors extends Error {
-  errors: { message: string; path: string }[];
+  errors: { message: string; path: string }[]
 
   constructor(errors: { message: string; path: string }[]) {
-    super(`${errors.length} errors`);
-    this.errors = errors;
+    super(`${errors.length} errors`)
+    this.errors = errors
   }
 }
 
@@ -63,12 +63,12 @@ class InputErrors extends Error {
  * })
  */
 class EnvironmentError extends Error {
-  path: string;
+  path: string
 
   constructor(message: string, path: string) {
-    super(message);
-    this.name = "EnvironmentError";
-    this.path = path;
+    super(message)
+    this.name = 'EnvironmentError'
+    this.path = path
   }
 }
 
@@ -83,27 +83,24 @@ class EnvironmentError extends Error {
  * })
  */
 class ResultError extends Error {
-  result: ErrorResult;
+  result: ErrorResult
 
   constructor(result: AtLeastOne<ErrorData>) {
-    super("ResultError");
-    this.name = "ResultError";
+    super('ResultError')
+    this.name = 'ResultError'
     this.result = {
       errors: [],
       inputErrors: [],
       environmentErrors: [],
       ...result,
       success: false,
-    };
+    }
   }
 }
 
 function schemaErrorToErrorWithMessage(se: SchemaError): ErrorWithMessage {
-  const message = `${se.path.join(".")} ${se.message}`.trim();
-  return {
-    message,
-    exception: new Error(message),
-  };
+  const message = `${se.path.join('.')} ${se.message}`.trim()
+  return new Error(message)
 }
 function errorResultToFailure({
   errors,
@@ -117,7 +114,7 @@ function errorResultToFailure({
       ...inputErrors.map(schemaErrorToErrorWithMessage),
       ...environmentErrors.map(schemaErrorToErrorWithMessage),
     ],
-  };
+  }
 }
 
 function failureToErrorResult({ errors }: Failure): ErrorResult {
@@ -125,46 +122,44 @@ function failureToErrorResult({ errors }: Failure): ErrorResult {
     success: false,
     errors: errors
       .filter(
-        ({ exception }) =>
+        (exception) =>
           !(
             exception instanceof InputError ||
             exception instanceof InputErrors ||
             exception instanceof EnvironmentError
           ),
       )
-      .flatMap((e) =>
-        e.exception instanceof ResultError ? e.exception.result.errors : e
-      ),
-    inputErrors: errors.flatMap(({ exception }) =>
+      .flatMap((e) => (e instanceof ResultError ? e.result.errors : e)),
+    inputErrors: errors.flatMap((exception) =>
       exception instanceof InputError
         ? [
-          {
-            path: exception.path.split("."),
-            message: exception.message,
-          },
-        ]
+            {
+              path: exception.path.split('.'),
+              message: exception.message,
+            },
+          ]
         : exception instanceof InputErrors
         ? exception.errors.map((e) => ({
-          path: e.path.split("."),
-          message: e.message,
-        }))
+            path: e.path.split('.'),
+            message: e.message,
+          }))
         : exception instanceof ResultError
         ? exception.result.inputErrors
-        : []
+        : [],
     ),
-    environmentErrors: errors.flatMap(({ exception }) =>
+    environmentErrors: errors.flatMap((exception) =>
       exception instanceof EnvironmentError
         ? [
-          {
-            path: exception.path.split("."),
-            message: exception.message,
-          },
-        ]
+            {
+              path: exception.path.split('.'),
+              message: exception.message,
+            },
+          ]
         : exception instanceof ResultError
         ? exception.result.environmentErrors
-        : []
+        : [],
     ),
-  };
+  }
 }
 
 export {
@@ -176,4 +171,4 @@ export {
   InputErrors,
   ResultError,
   schemaError,
-};
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,7 +3,6 @@ import type {
   AtLeastOne,
   ErrorData,
   ErrorResult,
-  ErrorWithMessage,
   SchemaError,
 } from './types.ts'
 
@@ -98,7 +97,7 @@ class ResultError extends Error {
   }
 }
 
-function schemaErrorToErrorWithMessage(se: SchemaError): ErrorWithMessage {
+function schemaErrorToError(se: SchemaError): Error {
   const message = `${se.path.join('.')} ${se.message}`.trim()
   return new Error(message)
 }
@@ -111,8 +110,8 @@ function errorResultToFailure({
     success: false,
     errors: [
       ...errors,
-      ...inputErrors.map(schemaErrorToErrorWithMessage),
-      ...environmentErrors.map(schemaErrorToErrorWithMessage),
+      ...inputErrors.map(schemaErrorToError),
+      ...environmentErrors.map(schemaErrorToError),
     ],
   }
 }

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -5,6 +5,7 @@ import { mdf } from './constructor.ts'
 import { first } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { assertObjectMatch } from 'https://deno.land/std@0.206.0/assert/assert_object_match.ts'
 
 describe('first', () => {
   it('should return the result of the first successful domain function', async () => {
@@ -53,9 +54,9 @@ describe('first', () => {
     const c = first(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<string>>>
 
-    assertEquals(await c({ id: 1 }), {
+    assertObjectMatch(await c({ id: 1 }), {
       success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
+      errors: [{ message: 'Error' }],
       inputErrors: [
         {
           message: 'Expected string, received number',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,14 +10,13 @@ export * from './errors.ts'
 export { mergeObjects } from './composable/composable.ts'
 export type { Composable } from './composable/index.ts'
 import * as composable from './composable/index.ts'
-export { toErrorWithMessage } from './composable/errors.ts'
+export { toError } from './composable/errors.ts'
 export { composable as cf }
 export type {
   AtLeastOne,
   DomainFunction,
   ErrorData,
   ErrorResult,
-  ErrorWithMessage,
   Last,
   MergeObjs,
   ParserIssue,
@@ -32,4 +31,3 @@ export type {
   UnpackResult,
   UnpackSuccess,
 } from './types.ts'
-

--- a/src/map-error.test.ts
+++ b/src/map-error.test.ts
@@ -5,6 +5,7 @@ import { mdf } from './constructor.ts'
 import { mapError } from './domain-functions.ts'
 import type { DomainFunction, ErrorData } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { assertObjectMatch } from 'https://deno.land/std@0.206.0/assert/assert_object_match.ts'
 
 describe('mapError', () => {
   it('returns the result when the domain function suceeds', async () => {
@@ -32,7 +33,7 @@ describe('mapError', () => {
     const a = mdf(z.object({ id: z.number() }))(({ id }) => id + 1)
     const b = (result: ErrorData) =>
       ({
-        errors: [{ message: exception.message, exception }],
+        errors: [exception],
         environmentErrors: [],
         inputErrors: [
           {
@@ -47,7 +48,7 @@ describe('mapError', () => {
 
     assertEquals(await c({ invalidInput: '1' }), {
       success: false,
-      errors: [{ message: 'Number of errors: 0', exception }],
+      errors: [exception],
       environmentErrors: [],
       inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
     })
@@ -62,9 +63,9 @@ describe('mapError', () => {
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ invalidInput: '1' }), {
+    assertObjectMatch(await c({ invalidInput: '1' }), {
       success: false,
-      errors: [{ message: 'failed to map', exception: 'failed to map' }],
+      errors: [{ message: 'failed to map' }],
       inputErrors: [],
       environmentErrors: [],
     })

--- a/src/map-error.test.ts
+++ b/src/map-error.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assertEquals } from './test-prelude.ts'
+import { assertEquals, describe, it } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
 import { mdf } from './constructor.ts'
@@ -13,7 +13,7 @@ describe('mapError', () => {
       ({
         errors: [{ message: 'New Error Message' }],
         inputErrors: [{ message: 'New Input Error Message' }],
-      } as ErrorData)
+      }) as ErrorData
 
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
@@ -28,10 +28,11 @@ describe('mapError', () => {
   })
 
   it('returns a domain function function that will apply a function over the error of the first one', async () => {
+    const exception = new Error('Number of errors: 0')
     const a = mdf(z.object({ id: z.number() }))(({ id }) => id + 1)
     const b = (result: ErrorData) =>
       ({
-        errors: [{ message: 'Number of errors: ' + result.errors.length }],
+        errors: [{ message: exception.message, exception }],
         environmentErrors: [],
         inputErrors: [
           {
@@ -39,14 +40,14 @@ describe('mapError', () => {
             path: [],
           },
         ],
-      } as ErrorData)
+      }) as ErrorData
 
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
     assertEquals(await c({ invalidInput: '1' }), {
       success: false,
-      errors: [{ message: 'Number of errors: 0' }],
+      errors: [{ message: 'Number of errors: 0', exception }],
       environmentErrors: [],
       inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
     })

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -5,6 +5,7 @@ import { mdf } from './constructor.ts'
 import { map } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { assertObjectMatch } from 'https://deno.land/std@0.206.0/assert/assert_object_match.ts'
 
 describe('map', () => {
   it('returns a domain function function that will apply a function over the results of the first one', async () => {
@@ -48,9 +49,9 @@ describe('map', () => {
     const c = map(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<never>>>
 
-    assertEquals(await c({ id: 1 }), {
+    assertObjectMatch(await c({ id: 1 }), {
       success: false,
-      errors: [{ message: 'failed to map', exception: 'failed to map' }],
+      errors: [{ message: 'failed to map' }],
       inputErrors: [],
       environmentErrors: [],
     })

--- a/src/merge.test.ts
+++ b/src/merge.test.ts
@@ -114,9 +114,9 @@ describe('merge', () => {
     const c: DomainFunction<never> = merge(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<never>>>
 
-    assertEquals(await c({ id: 1 }), {
+    assertObjectMatch(await c({ id: 1 }), {
       success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
+      errors: [{ message: 'Error' }],
       inputErrors: [],
       environmentErrors: [],
     })
@@ -165,10 +165,7 @@ describe('merge', () => {
 
     assertObjectMatch(await c({ id: 1 }), {
       success: false,
-      errors: [
-        { message: 'Error A', exception: { message: 'Error A' } },
-        { message: 'Error B', exception: { message: 'Error B' } },
-      ],
+      errors: [{ message: 'Error A' }, { message: 'Error B' }],
       inputErrors: [],
       environmentErrors: [],
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,7 +121,6 @@ type ParserSchema<T extends unknown = unknown> = {
 
 export type {
   AtLeastOne,
-  ErrorWithMessage,
   Last,
   MergeObjs,
   TupleToUnion,
@@ -142,4 +141,3 @@ export type {
   UnpackResult,
   UnpackSuccess,
 }
-


### PR DESCRIPTION
This PR brings a breaking change proposed for the next major version.
It drops the optional `exception` property present in `ErrorWithMessage` in favour of always using an `Error` type to represent errors.

The `Error` already carries a message, hence once the exception becomes mandatory the wrapping object becomes entirely redundant.
Moreover, having an optional `exception` does not make a lot of sense since the only way to return a result with the `errors` property is by using exceptions.

The code-base gets a bit tidier and checking for exception types becomes simpler. There is also didactic value since every TS developer should already be familiar with `Error`.

- Ensure our ErrorWithMessage type always has an attched exception
- Simplify ErrorWithMessage so it's just an Error alias
