### PR TITLE
catchError combinator to recover from failed composable

### DIFF
--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -196,15 +196,12 @@ function map<T extends Composable, R>(
  */
 function catchError<T extends Fn, R>(
   fn: Composable<T>,
-  catcher: (
-    err: Omit<Failure, 'success'>,
-    ...originalInput: Parameters<T>
-  ) => R,
+  catcher: (err: Failure['errors'], ...originalInput: Parameters<T>) => R,
 ) {
   return (async (...args: Parameters<T>) => {
     const res = await fn(...args)
     if (res.success) return success(res.data)
-    return composable(catcher)(res, ...(args as any))
+    return composable(catcher)(res.errors, ...(args as any))
   }) as Composable<
     (
       ...args: Parameters<T>

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -194,18 +194,18 @@ function map<T extends Composable, R>(
  *  originalInput.id * -1
  * ))
  */
-function catchError<T extends Composable, R>(
-  fn: T,
+function catchError<T extends Fn, R>(
+  fn: Composable<T>,
   catcher: (
     err: Omit<Failure, 'success'>,
     ...originalInput: Parameters<T>
-  ) => UnpackResult<ReturnType<T>>,
+  ) => R,
 ) {
-  return (async (...args) => {
+  return (async (...args: Parameters<T>) => {
     const res = await fn(...args)
     if (res.success) return success(res.data)
     return composable(catcher)(res, ...(args as any))
-  }) as T
+  }) as Composable<(...args: Parameters<T>) => ReturnType<T> | R>
 }
 
 /**

--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -205,7 +205,15 @@ function catchError<T extends Fn, R>(
     const res = await fn(...args)
     if (res.success) return success(res.data)
     return composable(catcher)(res, ...(args as any))
-  }) as Composable<(...args: Parameters<T>) => ReturnType<T> | R>
+  }) as Composable<
+    (
+      ...args: Parameters<T>
+    ) => ReturnType<T> extends any[]
+      ? R extends never[]
+        ? ReturnType<T>
+        : ReturnType<T> | R
+      : ReturnType<T> | R
+  >
 }
 
 /**

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -384,7 +384,23 @@ describe('mapError', () => {
 })
 
 describe('catchError', () => {
-  it('receives an error as input to another composable', async () => {
+  it('changes the type to accomodate catcher return type', async () => {
+    const fn = catchError(faultyAdd, () => null)
+    const res = await fn(1, 2)
+
+    type _FN = Expect<
+      Equal<typeof fn, Composable<(a: number, b: number) => number | null>>
+    >
+    type _R = Expect<Equal<typeof res, Result<number | null>>>
+
+    assertEquals(res, {
+      success: true,
+      data: null,
+      errors: [],
+    })
+  })
+
+  it('receives an error as input to another function and returns a new composable', async () => {
     const fn = catchError(faultyAdd, (_error, a, b) => a + b)
     const res = await fn(1, 2)
 

--- a/src/composable/index.test.ts
+++ b/src/composable/index.test.ts
@@ -400,8 +400,10 @@ describe('catchError', () => {
     })
   })
 
-  it('receives an error as input to another function and returns a new composable', async () => {
-    const fn = catchError(faultyAdd, (_error, a, b) => a + b)
+  it('receives the list of errors as input to another function and returns a new composable', async () => {
+    const fn = catchError(faultyAdd, (errors, a, b) =>
+      errors.length > 1 ? NaN : a + b,
+    )
     const res = await fn(1, 2)
 
     type _FN = Expect<

--- a/src/composable/index.ts
+++ b/src/composable/index.ts
@@ -1,3 +1,12 @@
 export type { Composable, Result, ErrorWithMessage } from './types.ts'
 export { toErrorWithMessage } from './errors.ts'
-export { composable, pipe, map, mapError, sequence, all, collect } from './composable.ts'
+export {
+  catchError,
+  composable,
+  pipe,
+  map,
+  mapError,
+  sequence,
+  all,
+  collect,
+} from './composable.ts'

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -168,7 +168,7 @@ function pipe<T extends DomainFunction[]>(
   ...fns: T
 ): DomainFunction<Last<UnpackAll<T>>> {
   const last = <T>(ls: T[]): T => ls[ls.length - 1]
-  return map(sequence(...fns), last)
+  return map(sequence(...fns), last) as DomainFunction<Last<UnpackAll<T>>> 
 }
 
 /**


### PR DESCRIPTION
Implement combinator based on the [docs for a future version](https://github.com/seasonedcc/domain-functions/blob/composable-docs/composables.md).

I have changed its type since the document was written since it seems to me that the original input must be relayed for proper error handling (e.g. retry policies).
