### PR TITLE
Allow map and mapError in DFs to have async mapper function

### DIFF
--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -233,7 +233,7 @@ function sequence<Fns extends DomainFunction[]>(
  */
 function map<O, R>(
   dfn: DomainFunction<O>,
-  mapper: (element: O) => R,
+  mapper: (element: O) => R | Promise<R>,
 ): DomainFunction<R> {
   return ((input, environment) =>
     dfResultFromcomposable(
@@ -327,16 +327,16 @@ function fromSuccess<T extends DomainFunction>(
  */
 function mapError<O>(
   dfn: DomainFunction<O>,
-  mapper: (element: ErrorData) => ErrorData,
+  mapper: (element: ErrorData) => ErrorData | Promise<ErrorData>,
 ): DomainFunction<O> {
-  return async (input, environment) => {
+  return (async (input, environment) => {
     const result = await dfn(input, environment)
     if (result.success) return result
 
-    return safeResult(() => {
-      throw new ResultError({ ...mapper(result) })
+    return safeResult(async () => {
+      throw new ResultError({ ...(await mapper(result)) })
     })
-  }
+  }) as DomainFunction<O>
 }
 
 type TraceData<T> = {
@@ -394,4 +394,3 @@ export {
   sequence,
   trace,
 }
-

--- a/src/map-error.test.ts
+++ b/src/map-error.test.ts
@@ -13,7 +13,7 @@ describe('mapError', () => {
       ({
         errors: [{ message: 'New Error Message' }],
         inputErrors: [{ message: 'New Input Error Message' }],
-      } as ErrorData)
+      }) as ErrorData
 
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
@@ -39,7 +39,32 @@ describe('mapError', () => {
             path: [],
           },
         ],
-      } as ErrorData)
+      }) as ErrorData
+
+    const c = mapError(a, b)
+    type _R = Expect<Equal<typeof c, DomainFunction<number>>>
+
+    assertEquals(await c({ invalidInput: '1' }), {
+      success: false,
+      errors: [{ message: 'Number of errors: 0' }],
+      environmentErrors: [],
+      inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
+    })
+  })
+
+  it('returns a domain function function that will apply an async function over the error of the first one', async () => {
+    const a = mdf(z.object({ id: z.number() }))(({ id }) => id + 1)
+    const b = (result: ErrorData) =>
+      Promise.resolve({
+        errors: [{ message: 'Number of errors: ' + result.errors.length }],
+        environmentErrors: [],
+        inputErrors: [
+          {
+            message: 'Number of input errors: ' + result.inputErrors.length,
+            path: [],
+          },
+        ],
+      }) as Promise<ErrorData>
 
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -23,6 +23,22 @@ describe('map', () => {
     })
   })
 
+  it('returns a domain function function that will apply an async function over the results of the first one', async () => {
+    const a = mdf(z.object({ id: z.number() }))(({ id }) => id + 1)
+    const b = (id: number) => Promise.resolve(id + 1)
+
+    const c = map(a, b)
+    type _R = Expect<Equal<typeof c, DomainFunction<number>>>
+
+    assertEquals(await c({ id: 1 }), {
+      success: true,
+      data: 3,
+      errors: [],
+      inputErrors: [],
+      environmentErrors: [],
+    })
+  })
+
   it('returns the error when the domain function fails', async () => {
     const firstInputParser = z.object({ id: z.number() })
     const a = mdf(firstInputParser)(({ id }) => id + 1)


### PR DESCRIPTION
Do we have any reason to not allow this?
