### PR TITLE
Reimplement composable map in terms of pipe

### DIFF
--- a/src/composable/composable.ts
+++ b/src/composable/composable.ts
@@ -179,13 +179,9 @@ function map<T extends Composable, R>(
   fn: T,
   mapper: (res: UnpackResult<ReturnType<T>>) => R,
 ) {
-  return (async (...args) => {
-    const res = await fn(...args)
-    if (!res.success) return error(res.errors)
-    const mapped = await composable(mapper)(res.data)
-    if (!mapped.success) return error(mapped.errors)
-    return mapped
-  }) as Composable<(...args: Parameters<T>) => R>
+  return pipe(fn as Composable, composable(mapper) as Composable) as Composable<
+    (...args: Parameters<T>) => R
+  >
 }
 
 /**
@@ -226,4 +222,3 @@ export {
   sequence,
   success,
 }
-

--- a/src/domain-functions.ts
+++ b/src/domain-functions.ts
@@ -235,13 +235,9 @@ function map<O, R>(
   dfn: DomainFunction<O>,
   mapper: (element: O) => R | Promise<R>,
 ): DomainFunction<R> {
-  return ((input, environment) =>
-    dfResultFromcomposable(
-      A.map(
-        A.composable(() => fromSuccess(dfn)(input, environment)),
-        mapper,
-      ),
-    )()) as DomainFunction<R>
+  return dfResultFromcomposable(
+    A.map(A.composable(fromSuccess(dfn)), mapper),
+  ) as DomainFunction<R>
 }
 
 /**


### PR DESCRIPTION
This implementation seems cleaner and easier to understand.

Also simplified the DF map since I thought that the current code was still a bit awkward passing and applying parameters.