### PR TITLE
feat: Add and export makeSuccessResult and makeErrorResult helpers

### DIFF
--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -22,7 +22,7 @@ describe('all', () => {
 
     assertEquals(
       await c({ id: 1 }),
-      makeSuccessResult([2, 0] as [number, number]),
+      makeSuccessResult<[number, number]>([2, 0]),
     )
   })
 
@@ -36,7 +36,7 @@ describe('all', () => {
     const results = await d({ id: 1 })
     assertEquals(
       results,
-      makeSuccessResult(['1', 2, true] as [string, number, boolean]),
+      makeSuccessResult<[string, number, boolean]>(['1', 2, true]),
     )
   })
 

--- a/src/all.test.ts
+++ b/src/all.test.ts
@@ -6,10 +6,11 @@ import {
 } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
-import { mdf } from './constructor.ts'
+import { makeSuccessResult, mdf } from './constructor.ts'
 import { all } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('all', () => {
   it('should combine two domain functions into one', async () => {
@@ -19,13 +20,10 @@ describe('all', () => {
     const c = all(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<[number, number]>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: true,
-      data: [2, 0],
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeSuccessResult([2, 0] as [number, number]),
+    )
   })
 
   it('should combine many domain functions into one', async () => {
@@ -36,13 +34,10 @@ describe('all', () => {
     type _R = Expect<Equal<typeof d, DomainFunction<[string, number, boolean]>>>
 
     const results = await d({ id: 1 })
-    assertEquals(results, {
-      success: true,
-      data: ['1', 2, true],
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      results,
+      makeSuccessResult(['1', 2, true] as [string, number, boolean]),
+    )
   })
 
   it('should return error when one of the domain functions has input errors', async () => {
@@ -52,17 +47,14 @@ describe('all', () => {
     const c = all(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<[number, string]>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: false,
-      inputErrors: [
-        {
-          message: 'Expected string, received number',
-          path: ['id'],
-        },
-      ],
-      errors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeErrorResult({
+        inputErrors: [
+          { message: 'Expected string, received number', path: ['id'] },
+        ],
+      }),
+    )
   })
 
   it('should return error when one of the domain functions fails', async () => {
@@ -74,12 +66,12 @@ describe('all', () => {
     const c = all(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<[number, never]>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeErrorResult({
+        errors: [{ message: 'Error', exception: 'Error' }],
+      }),
+    )
   })
 
   it('should combine the inputError messages of both functions', async () => {
@@ -89,21 +81,15 @@ describe('all', () => {
     const c = all(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<[string, string]>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: false,
-      inputErrors: [
-        {
-          message: 'Expected string, received number',
-          path: ['id'],
-        },
-        {
-          message: 'Expected string, received number',
-          path: ['id'],
-        },
-      ],
-      environmentErrors: [],
-      errors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeErrorResult({
+        inputErrors: [
+          { message: 'Expected string, received number', path: ['id'] },
+          { message: 'Expected string, received number', path: ['id'] },
+        ],
+      }),
+    )
   })
 
   it('should combine the error messages when both functions fail', async () => {
@@ -117,11 +103,11 @@ describe('all', () => {
     const c = all(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<[never, never]>>>
 
-    assertObjectMatch(await c({ id: 1 }), {
-      success: false,
-      errors: [{ message: 'Error A' }, { message: 'Error B' }],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertObjectMatch(
+      await c({ id: 1 }),
+      makeErrorResult({
+        errors: [{ message: 'Error A' }, { message: 'Error B' }],
+      }),
+    )
   })
 })

--- a/src/apply-environment.test.ts
+++ b/src/apply-environment.test.ts
@@ -1,8 +1,9 @@
 import { assertEquals, describe, it } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
-import { mdf } from './constructor.ts'
+import { makeSuccessResult, mdf } from './constructor.ts'
 import { applyEnvironment } from './domain-functions.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('applyEnvironment', () => {
   it('fails when environment fails parser', async () => {
@@ -13,17 +14,14 @@ describe('applyEnvironment', () => {
       'invalid environment',
     )
 
-    assertEquals(await getEnvWithEnvironment('some input'), {
-      success: false,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [
-        {
-          message: 'Expected number, received string',
-          path: [],
-        },
-      ],
-    })
+    assertEquals(
+      await getEnvWithEnvironment('some input'),
+      makeErrorResult({
+        environmentErrors: [
+          { message: 'Expected number, received string', path: [] },
+        ],
+      }),
+    )
   })
 
   it('should apply environment', async () => {
@@ -34,13 +32,9 @@ describe('applyEnvironment', () => {
       'constant environment',
     )
 
-    assertEquals(await getEnvWithEnvironment('some input'), {
-      success: true,
-      data: 'constant environment',
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await getEnvWithEnvironment('some input'),
+      makeSuccessResult('constant environment'),
+    )
   })
 })
-

--- a/src/branch.test.ts
+++ b/src/branch.test.ts
@@ -146,7 +146,7 @@ describe('branch', () => {
 
     assertEquals(
       await d({ id: 1 }),
-      makeSuccessResult([4, { id: 3 }] as [number, { id: number }]),
+      makeSuccessResult<[number, { id: number }]>([4, { id: 3 }]),
     )
   })
 })

--- a/src/branch.test.ts
+++ b/src/branch.test.ts
@@ -6,10 +6,11 @@ import {
 } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
-import { mdf } from './constructor.ts'
+import { makeSuccessResult, mdf } from './constructor.ts'
 import { branch, pipe, all } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('branch', () => {
   it('should pipe a domain function with a function that returns a DF', async () => {
@@ -21,13 +22,7 @@ describe('branch', () => {
     const c = branch(a, () => Promise.resolve(b))
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: true,
-      data: 2,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(await c({ id: 1 }), makeSuccessResult(2))
   })
 
   it('should enable conditionally choosing the next DF with the output of first one', async () => {
@@ -40,13 +35,7 @@ describe('branch', () => {
     const d = branch(a, (output) => (output.next === 'multiply' ? c : b))
     type _R = Expect<Equal<typeof d, DomainFunction<number | string>>>
 
-    assertEquals(await d({ id: 1 }), {
-      success: true,
-      data: 6,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(await d({ id: 1 }), makeSuccessResult(6))
   })
 
   it('should not pipe if the predicate returns null', async () => {
@@ -60,13 +49,10 @@ describe('branch', () => {
       Equal<typeof d, DomainFunction<string | { id: number; next: string }>>
     >
 
-    assertEquals(await d({ id: 1 }), {
-      success: true,
-      data: { id: 3, next: 'multiply' },
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await d({ id: 1 }),
+      makeSuccessResult({ id: 3, next: 'multiply' }),
+    )
   })
 
   it('should use the same environment in all composed functions', async () => {
@@ -84,13 +70,7 @@ describe('branch', () => {
     const c = branch(a, () => b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c(undefined, { env: 1 }), {
-      success: true,
-      data: 4,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(await c(undefined, { env: 1 }), makeSuccessResult(4))
   })
 
   it('should gracefully fail if the first function fails', async () => {
@@ -101,17 +81,14 @@ describe('branch', () => {
     const c = branch(a, () => b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ id: '1' }), {
-      success: false,
-      errors: [],
-      inputErrors: [
-        {
-          path: ['id'],
-          message: 'Expected number, received string',
-        },
-      ],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: '1' }),
+      makeErrorResult({
+        inputErrors: [
+          { path: ['id'], message: 'Expected number, received string' },
+        ],
+      }),
+    )
   })
 
   it('should gracefully fail if the second function fails', async () => {
@@ -122,17 +99,14 @@ describe('branch', () => {
     const c = branch(a, () => b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: false,
-      errors: [],
-      inputErrors: [
-        {
-          path: ['id'],
-          message: 'Expected number, received string',
-        },
-      ],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeErrorResult({
+        inputErrors: [
+          { path: ['id'], message: 'Expected number, received string' },
+        ],
+      }),
+    )
   })
 
   it('should gracefully fail if the condition function fails', async () => {
@@ -147,12 +121,12 @@ describe('branch', () => {
     })
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertObjectMatch(await c({ id: 1 }), {
-      success: false,
-      errors: [{ message: 'condition function failed' }],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertObjectMatch(
+      await c({ id: 1 }),
+      makeErrorResult({
+        errors: [{ message: 'condition function failed' }],
+      }),
+    )
   })
 
   it('should not break composition with other combinators', async () => {
@@ -170,12 +144,9 @@ describe('branch', () => {
     )
     type _R = Expect<Equal<typeof d, DomainFunction<[number, { id: number }]>>>
 
-    assertEquals(await d({ id: 1 }), {
-      data: [4, { id: 3 }],
-      success: true,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await d({ id: 1 }),
+      makeSuccessResult([4, { id: 3 }] as [number, { id: number }]),
+    )
   })
 })

--- a/src/constructor.ts
+++ b/src/constructor.ts
@@ -13,7 +13,7 @@ import type {
 import { Composable } from './composable/index.ts'
 import { composable } from './composable/composable.ts'
 
-function makeSuccessResult<T>(data: T): SuccessResult<T> {
+function makeSuccessResult<const T>(data: T): SuccessResult<T> {
   return {
     success: true,
     data,

--- a/src/constructor.ts
+++ b/src/constructor.ts
@@ -1,20 +1,33 @@
-import { errorResultToFailure, failureToErrorResult } from './errors.ts'
+import {
+  errorResultToFailure,
+  failureToErrorResult,
+  makeErrorResult,
+} from './errors.ts'
 import type {
   DomainFunction,
   ParserIssue,
   ParserSchema,
   SchemaError,
+  SuccessResult,
 } from './types.ts'
 import { Composable } from './composable/index.ts'
 import { composable } from './composable/composable.ts'
+
+function makeSuccessResult<T>(data: T): SuccessResult<T> {
+  return {
+    success: true,
+    data,
+    inputErrors: [],
+    errors: [],
+    environmentErrors: [],
+  }
+}
 
 function dfResultFromcomposable<T extends Composable, R>(fn: T) {
   return (async (...args) => {
     const r = await fn(...args)
 
-    return r.success
-      ? { ...r, inputErrors: [], environmentErrors: [] }
-      : failureToErrorResult(r)
+    return r.success ? makeSuccessResult(r.data) : failureToErrorResult(r)
   }) as Composable<(...args: Parameters<T>) => R>
 }
 
@@ -73,16 +86,14 @@ function fromComposable<I, E, A extends Composable>(
     const result = await (inputSchema ?? undefinedSchema).safeParseAsync(input)
 
     if (!result.success || !envResult.success) {
-      return {
-        success: false,
-        errors: [],
+      return makeErrorResult({
         inputErrors: result.success
           ? []
           : formatSchemaErrors(result.error.issues),
         environmentErrors: envResult.success
           ? []
           : formatSchemaErrors(envResult.error.issues),
-      }
+      })
     }
     return dfResultFromcomposable(fn)(
       ...([result.data as I, envResult.data as E] as Parameters<A>),
@@ -121,5 +132,5 @@ export {
   makeDomainFunction,
   makeDomainFunction as mdf,
   toComposable,
+  makeSuccessResult,
 }
-

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -88,13 +88,7 @@ class ResultError extends Error {
   constructor(result: AtLeastOne<ErrorData>) {
     super('ResultError')
     this.name = 'ResultError'
-    this.result = {
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-      ...result,
-      success: false,
-    }
+    this.result = makeErrorResult(result)
   }
 }
 
@@ -119,8 +113,7 @@ function errorResultToFailure({
 }
 
 function failureToErrorResult({ errors }: Failure): ErrorResult {
-  return {
-    success: false,
+  return makeErrorResult({
     errors: errors
       .filter(
         ({ exception }) =>
@@ -162,7 +155,17 @@ function failureToErrorResult({ errors }: Failure): ErrorResult {
         ? exception.result.environmentErrors
         : [],
     ),
-  }
+  })
+}
+
+function makeErrorResult(errorData: AtLeastOne<ErrorData>) {
+  return {
+    success: false,
+    errors: [],
+    inputErrors: [],
+    environmentErrors: [],
+    ...errorData,
+  } as ErrorResult
 }
 
 export {
@@ -174,5 +177,5 @@ export {
   InputErrors,
   ResultError,
   schemaError,
+  makeErrorResult,
 }
-

--- a/src/first.test.ts
+++ b/src/first.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, assertEquals } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
-import { mdf } from './constructor.ts'
+import { makeSuccessResult, mdf } from './constructor.ts'
 import { first } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('first', () => {
   it('should return the result of the first successful domain function', async () => {
@@ -15,13 +16,7 @@ describe('first', () => {
     type _R = Expect<Equal<typeof d, DomainFunction<string | number | boolean>>>
 
     const results = await d({ id: 1 })
-    assertEquals(results, {
-      success: true,
-      data: '1',
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(results, makeSuccessResult('1'))
   })
 
   it('should return a successful result even if one of the domain functions fails', async () => {
@@ -35,13 +30,10 @@ describe('first', () => {
     const c = first(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ n: 1, operation: 'increment' }), {
-      success: true,
-      data: 2,
-      inputErrors: [],
-      errors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ n: 1, operation: 'increment' }),
+      makeSuccessResult(2),
+    )
   })
 
   it('should return error when all of the domain functions fails', async () => {
@@ -53,16 +45,14 @@ describe('first', () => {
     const c = first(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<string>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: false,
-      errors: [{ message: 'Error', exception: 'Error' }],
-      inputErrors: [
-        {
-          message: 'Expected string, received number',
-          path: ['id'],
-        },
-      ],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeErrorResult({
+        errors: [{ message: 'Error', exception: 'Error' }],
+        inputErrors: [
+          { message: 'Expected string, received number', path: ['id'] },
+        ],
+      }),
+    )
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   makeDomainFunction,
   mdf,
   toComposable,
+  makeSuccessResult,
 } from './constructor.ts'
 export * from './domain-functions.ts'
 export * from './input-resolvers.ts'
@@ -32,4 +33,3 @@ export type {
   UnpackResult,
   UnpackSuccess,
 } from './types.ts'
-

--- a/src/map-error.test.ts
+++ b/src/map-error.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, assertEquals } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
-import { mdf } from './constructor.ts'
+import { makeSuccessResult, mdf } from './constructor.ts'
 import { mapError } from './domain-functions.ts'
 import type { DomainFunction, ErrorData } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('mapError', () => {
   it('returns the result when the domain function suceeds', async () => {
@@ -13,18 +14,12 @@ describe('mapError', () => {
       ({
         errors: [{ message: 'New Error Message' }],
         inputErrors: [{ message: 'New Input Error Message' }],
-      }) as ErrorData
+      } as ErrorData)
 
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: true,
-      data: 2,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(await c({ id: 1 }), makeSuccessResult(2))
   })
 
   it('returns a domain function function that will apply a function over the error of the first one', async () => {
@@ -39,17 +34,18 @@ describe('mapError', () => {
             path: [],
           },
         ],
-      }) as ErrorData
+      } as ErrorData)
 
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ invalidInput: '1' }), {
-      success: false,
-      errors: [{ message: 'Number of errors: 0' }],
-      environmentErrors: [],
-      inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
-    })
+    assertEquals(
+      await c({ invalidInput: '1' }),
+      makeErrorResult({
+        errors: [{ message: 'Number of errors: 0' }],
+        inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
+      }),
+    )
   })
 
   it('returns a domain function function that will apply an async function over the error of the first one', async () => {
@@ -69,12 +65,13 @@ describe('mapError', () => {
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ invalidInput: '1' }), {
-      success: false,
-      errors: [{ message: 'Number of errors: 0' }],
-      environmentErrors: [],
-      inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
-    })
+    assertEquals(
+      await c({ invalidInput: '1' }),
+      makeErrorResult({
+        errors: [{ message: 'Number of errors: 0' }],
+        inputErrors: [{ message: 'Number of input errors: 1', path: [] }],
+      }),
+    )
   })
 
   it('returns the error when the mapping function fails', async () => {
@@ -86,11 +83,11 @@ describe('mapError', () => {
     const c = mapError(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ invalidInput: '1' }), {
-      success: false,
-      errors: [{ message: 'failed to map', exception: 'failed to map' }],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ invalidInput: '1' }),
+      makeErrorResult({
+        errors: [{ message: 'failed to map', exception: 'failed to map' }],
+      }),
+    )
   })
 })

--- a/src/map.test.ts
+++ b/src/map.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, assertEquals } from './test-prelude.ts'
 import { z } from './test-prelude.ts'
 
-import { mdf } from './constructor.ts'
+import { makeSuccessResult, mdf } from './constructor.ts'
 import { map } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('map', () => {
   it('returns a domain function function that will apply a function over the results of the first one', async () => {
@@ -14,13 +15,7 @@ describe('map', () => {
     const c = map(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: true,
-      data: 3,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(await c({ id: 1 }), makeSuccessResult(3))
   })
 
   it('returns a domain function function that will apply an async function over the results of the first one', async () => {
@@ -30,13 +25,7 @@ describe('map', () => {
     const c = map(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: true,
-      data: 3,
-      errors: [],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(await c({ id: 1 }), makeSuccessResult(3))
   })
 
   it('returns the error when the domain function fails', async () => {
@@ -47,12 +36,12 @@ describe('map', () => {
     const c = map(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<number>>>
 
-    assertEquals(await c({ invalidInput: '1' }), {
-      success: false,
-      errors: [],
-      inputErrors: [{ message: 'Required', path: ['id'] }],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ invalidInput: '1' }),
+      makeErrorResult({
+        inputErrors: [{ message: 'Required', path: ['id'] }],
+      }),
+    )
   })
 
   it('returns the error when the mapping function fails', async () => {
@@ -64,11 +53,11 @@ describe('map', () => {
     const c = map(a, b)
     type _R = Expect<Equal<typeof c, DomainFunction<never>>>
 
-    assertEquals(await c({ id: 1 }), {
-      success: false,
-      errors: [{ message: 'failed to map', exception: 'failed to map' }],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertEquals(
+      await c({ id: 1 }),
+      makeErrorResult({
+        errors: [{ message: 'failed to map', exception: 'failed to map' }],
+      }),
+    )
   })
 })

--- a/src/sequence.test.ts
+++ b/src/sequence.test.ts
@@ -23,9 +23,9 @@ describe('sequence', () => {
 
     assertEquals(
       await c({ id: 1 }),
-      makeSuccessResult([{ id: 3 }, { result: 2 }] as [
-        { id: number },
-        { result: number },
+      makeSuccessResult<[{ id: number }, { result: number }]>([
+        { id: 3 },
+        { result: 2 },
       ]),
     )
   })
@@ -49,9 +49,9 @@ describe('sequence', () => {
 
     assertEquals(
       await c(undefined, { env: 1 }),
-      makeSuccessResult([{ inp: 3 }, { result: 4 }] as [
-        { inp: number },
-        { result: number },
+      makeSuccessResult<[{ inp: number }, { result: number }]>([
+        { inp: 3 },
+        { result: 4 },
       ]),
     )
   })
@@ -159,15 +159,13 @@ describe('sequence', () => {
 
     assertEquals(
       await d({ aNumber: 1 }),
-      makeSuccessResult([
-        { aString: '1' },
-        { aBoolean: true },
-        { anotherBoolean: false },
-      ] as [
-        { aString: string },
-        { aBoolean: boolean },
-        { anotherBoolean: boolean },
-      ]),
+      makeSuccessResult<
+        [
+          { aString: string },
+          { aBoolean: boolean },
+          { anotherBoolean: boolean },
+        ]
+      >([{ aString: '1' }, { aBoolean: true }, { anotherBoolean: false }]),
     )
   })
 })

--- a/src/trace.test.ts
+++ b/src/trace.test.ts
@@ -10,6 +10,7 @@ import { mdf } from './constructor.ts'
 import { fromSuccess, trace } from './domain-functions.ts'
 import type { DomainFunction } from './types.ts'
 import type { Equal, Expect } from './types.test.ts'
+import { makeErrorResult } from './errors.ts'
 
 describe('trace', () => {
   it('converts trace exceptions to df failures', async () => {
@@ -22,12 +23,12 @@ describe('trace', () => {
 
     const result = await c({ id: 1 })
 
-    assertObjectMatch(result, {
-      success: false,
-      errors: [{ message: 'Problem in tracing' }],
-      inputErrors: [],
-      environmentErrors: [],
-    })
+    assertObjectMatch(
+      result,
+      makeErrorResult({
+        errors: [{ message: 'Problem in tracing' }],
+      }),
+    )
   })
 
   it('intercepts inputs and outputs of a given domain function', async () => {
@@ -58,4 +59,3 @@ describe('trace', () => {
     })
   })
 })
-


### PR DESCRIPTION
Often times, especially in tests, we want to construct the `Result` type and we have to type all the structure.
These functions should help with that by allowing us to construct an ErrorResult like so:
```ts
// before: 
const error: ErrorResult = {
  success: false,
  errors: [myError],
  environmentErrors: [],
  inputErrors: [],
}

// after:
const error: ErrorResult = makeErrorResult({ errors: [MyError] })
```

or a SuccessResult like so:
```ts
// before: 
const result: SuccessResult = {
  success: true,
  data,
  errors: [],
  inputErrors: [],
  environmentErrors: [],
}

// after:
const result: SuccessResult = makeSuccessResult(data)
```